### PR TITLE
19 remove after commit upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
           bundle exec rails test
 
       - uses: actions/upload-artifact@v3
+        name: Upload coverage
+        if: failure()
         with:
           name: Coverage
           path: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         run: |
           bundle exec rails test
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Coverage
+          path: coverage
+
   lint:
     runs-on: ubuntu-latest
 

--- a/.simplecov
+++ b/.simplecov
@@ -6,5 +6,6 @@ SimpleCov.start do
 
   add_filter "/test/"
 
-  SimpleCov.minimum_coverage 100
+  minimum_coverage line: 100, branch: 100
+  refuse_coverage_drop :line, :branch
 end

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -30,6 +30,12 @@ module StorageTables
       "#{partition_key}#{self[:checksum]}=="
     end
 
+    def destroy!
+      raise StorageTables::ActiveRecordError, "Cannot delete blob attached to a record" if attachments_count.positive?
+
+      super
+    end
+
     class << self
       def build_after_unfurling(io:, content_type: nil, metadata: nil)
         new_blob = new(content_type:, metadata:)

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -33,6 +33,7 @@ module StorageTables
     def destroy!
       raise StorageTables::ActiveRecordError, "Cannot delete blob attached to a record" if attachments_count.positive?
 
+      service.delete(checksum)
       super
     end
 

--- a/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
+++ b/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
 class AddUniqueIndexOnBlobChecksum < ActiveRecord::Migration[7.0]
-  def change
+  def up
     add_index :storage_tables_blobs, :checksum, where: "attachments_count = 0"
+    
+    ActiveRecord::Base.connection.execute <<~SQL.squish
+      CREATE OR REPLACE FUNCTION public.partition_keys() RETURNS text[]
+      LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+          AS $$
+      DECLARE
+        list TEXT[] := '{A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,0,1,2,3,4,5,6,7,8,9,+,/}';
+      BEGIN
+      RETURN list;
+      END;
+      $$;
+    SQL
 
     ActiveRecord::Base.connection.execute <<~SQL.squish
       CREATE OR REPLACE FUNCTION public.increment_attachment_counter() RETURNS trigger
@@ -14,22 +26,42 @@ class AddUniqueIndexOnBlobChecksum < ActiveRecord::Migration[7.0]
             attachments_count_modified = CURRENT_TIMESTAMP
         WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum;
         RETURN NULL;
+        END;
+        $$;
+        SQL
+        
+    ActiveRecord::Base.connection.execute <<~SQL.squish
+      CREATE OR REPLACE FUNCTION public.decrement_attachment_counter() RETURNS trigger
+        LANGUAGE plpgsql VOLATILE
+        AS $$
+        DECLARE
+        index integer;
+        BEGIN
+        UPDATE storage_tables_blobs
+        SET attachments_count = attachments_count - 1,
+            attachments_count_modified = CURRENT_TIMESTAMP
+        WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum;
+        RETURN NULL;
       END;
       $$;
     SQL
 
     ActiveRecord::Base.connection.execute <<~SQL.squish
-      CREATE OR REPLACE FUNCTION public.decrement_attachment_counter() RETURNS trigger
-      LANGUAGE plpgsql VOLATILE
-      AS $$
-      BEGIN
-        UPDATE storage_tables_blobs
-        SET attachments_count = attachments_count - 1,
-            attachments_count_modified = CURRENT_TIMESTAMP
-        WHERE partition_key = OLD.blob_key AND checksum = OLD.checksum;
-        RETURN NULL;
-      END;
-      $$;
+      CREATE OR REPLACE FUNCTION public.immutable_blob_key_and_checksum() RETURNS trigger
+        LANGUAGE plpgsql VOLATILE
+        AS $$
+        
+          BEGIN
+          IF NEW.checksum <> OLD.checksum THEN
+                RAISE EXCEPTION 'updating checksum not allowed';
+          END IF;
+          IF NEW.partition_key <> OLD.partition_key THEN
+                RAISE EXCEPTION 'updating partition_key not allowed';
+          END IF;
+          RETURN NEW;
+            
+          END;
+        $$;
     SQL
   end
 end

--- a/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
+++ b/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
@@ -3,18 +3,6 @@
 class AddUniqueIndexOnBlobChecksum < ActiveRecord::Migration[7.0]
   def up
     add_index :storage_tables_blobs, :checksum, where: "attachments_count = 0"
-    
-    ActiveRecord::Base.connection.execute <<~SQL.squish
-      CREATE OR REPLACE FUNCTION public.partition_keys() RETURNS text[]
-      LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
-          AS $$
-      DECLARE
-        list TEXT[] := '{A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,0,1,2,3,4,5,6,7,8,9,+,/}';
-      BEGIN
-      RETURN list;
-      END;
-      $$;
-    SQL
 
     ActiveRecord::Base.connection.execute <<~SQL.squish
       CREATE OR REPLACE FUNCTION public.increment_attachment_counter() RETURNS trigger

--- a/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
+++ b/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
@@ -12,7 +12,7 @@ class AddUniqueIndexOnBlobChecksum < ActiveRecord::Migration[7.0]
         UPDATE storage_tables_blobs
         SET attachments_count = attachments_count + 1,
             attachments_count_modified = CURRENT_TIMESTAMP
-        WHERE checksum = NEW.checksum;
+        WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum;
         RETURN NEW;
       END;
       $$;
@@ -26,8 +26,8 @@ class AddUniqueIndexOnBlobChecksum < ActiveRecord::Migration[7.0]
         UPDATE storage_tables_blobs
         SET attachments_count = attachments_count - 1,
             attachments_count_modified = CURRENT_TIMESTAMP
-        WHERE checksum = NEW.checksum;
-        RETURN NEW;
+        WHERE partition_key = OLD.blob_key AND checksum = OLD.checksum;
+        RETURN OLD;
       END;
       $$;
     SQL

--- a/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
+++ b/db/migrate/20230914064811_add_unique_index_on_blob_checksum.rb
@@ -13,7 +13,7 @@ class AddUniqueIndexOnBlobChecksum < ActiveRecord::Migration[7.0]
         SET attachments_count = attachments_count + 1,
             attachments_count_modified = CURRENT_TIMESTAMP
         WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum;
-        RETURN NEW;
+        RETURN NULL;
       END;
       $$;
     SQL
@@ -27,7 +27,7 @@ class AddUniqueIndexOnBlobChecksum < ActiveRecord::Migration[7.0]
         SET attachments_count = attachments_count - 1,
             attachments_count_modified = CURRENT_TIMESTAMP
         WHERE partition_key = OLD.blob_key AND checksum = OLD.checksum;
-        RETURN OLD;
+        RETURN NULL;
       END;
       $$;
     SQL

--- a/db/migrate/20230914102244_create_partitions_for_storage_blobs.rb
+++ b/db/migrate/20230914102244_create_partitions_for_storage_blobs.rb
@@ -1,8 +1,8 @@
 class CreatePartitionsForStorageBlobs < ActiveRecord::Migration[7.0]
-  def up    
+  def up
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("").each_with_index do |char, index|
       ActiveRecord::Base.connection.execute <<~SQL.squish
-      CREATE TABLE storage_tables_blobs_partition_#{index} PARTITION OF storage_tables_blobs
+        CREATE TABLE storage_tables_blobs_partition_#{index} PARTITION OF storage_tables_blobs
         FOR VALUES IN ('#{char}');
       SQL
       ActiveRecord::Base.connection.execute <<~SQL.squish

--- a/db/migrate/20230914102244_create_partitions_for_storage_blobs.rb
+++ b/db/migrate/20230914102244_create_partitions_for_storage_blobs.rb
@@ -1,9 +1,12 @@
 class CreatePartitionsForStorageBlobs < ActiveRecord::Migration[7.0]
-  def up
+  def up    
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("").each_with_index do |char, index|
       ActiveRecord::Base.connection.execute <<~SQL.squish
-        CREATE TABLE storage_tables_blobs_partition_#{index} PARTITION OF storage_tables_blobs
+      CREATE TABLE storage_tables_blobs_partition_#{index} PARTITION OF storage_tables_blobs
         FOR VALUES IN ('#{char}');
+      SQL
+      ActiveRecord::Base.connection.execute <<~SQL.squish
+        CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON storage_tables_blobs_partition_#{index} FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum()
       SQL
     end
   end

--- a/lib/storage_tables/attachable/changes/create_one.rb
+++ b/lib/storage_tables/attachable/changes/create_one.rb
@@ -28,21 +28,6 @@ module StorageTables
           record.public_send("#{name}_storage_blob=", blob)
         end
 
-        def upload
-          case attachable
-          when ActionDispatch::Http::UploadedFile, Pathname
-            blob.upload_without_unfurling(attachable.open)
-          when Rack::Test::UploadedFile
-            blob.upload_without_unfurling(
-              attachable.respond_to?(:open) ? attachable.open : attachable
-            )
-          when Hash
-            blob.upload_without_unfurling(attachable.fetch(:io))
-          when File
-            blob.upload_without_unfurling(attachable)
-          end
-        end
-
         private
 
         def find_or_build_attachment

--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -34,9 +34,11 @@ module StorageTables
             includes("#{name}_storage_attachment": :blob)
           }
 
+          before_save { attachment_changes[name.to_s]&.upload }
           after_save { attachment_changes[name.to_s]&.save }
+          after_commit(on: [:create, :update]) { attachment_changes.delete(name.to_s) }
 
-          after_commit(on: [:create, :update]) { attachment_changes.delete(name.to_s).try(:upload) }
+          after_rollback { binding.pry }
 
           reflection = ActiveRecord::Reflection.create(
             :stored_one_attachment,

--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -34,11 +34,8 @@ module StorageTables
             includes("#{name}_storage_attachment": :blob)
           }
 
-          before_save { attachment_changes[name.to_s]&.upload }
           after_save { attachment_changes[name.to_s]&.save }
           after_commit(on: [:create, :update]) { attachment_changes.delete(name.to_s) }
-
-          after_rollback { binding.pry }
 
           reflection = ActiveRecord::Reflection.create(
             :stored_one_attachment,

--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -35,7 +35,6 @@ module StorageTables
           }
 
           after_save { attachment_changes[name.to_s]&.save }
-          after_commit(on: [:create, :update]) { attachment_changes.delete(name.to_s) }
 
           reflection = ActiveRecord::Reflection.create(
             :stored_one_attachment,

--- a/lib/storage_tables/attachable/one.rb
+++ b/lib/storage_tables/attachable/one.rb
@@ -16,7 +16,6 @@ module StorageTables
       #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
       def attach(attachable, filename:)
         record.public_send("#{name}=", attachable, filename)
-        binding.pry
         blob.save! && upload(attachable)
         # :nocov:
         return if record.persisted? && !record.changed? && !record.save
@@ -39,7 +38,6 @@ module StorageTables
           blob.upload_without_unfurling(attachable)
         end
       rescue StandardError => e
-        binding.pry
         blob.destroy!
         raise e
       end

--- a/lib/storage_tables/attachable/one.rb
+++ b/lib/storage_tables/attachable/one.rb
@@ -37,9 +37,9 @@ module StorageTables
         when File
           blob.upload_without_unfurling(attachable)
         end
-      rescue StandardError => e
+      rescue StandardError
         blob.destroy!
-        raise e
+        raise
       end
 
       # Returns the associated attachment record.

--- a/lib/storage_tables/attachable/one.rb
+++ b/lib/storage_tables/attachable/one.rb
@@ -16,6 +16,7 @@ module StorageTables
       #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
       def attach(attachable, filename:)
         record.public_send("#{name}=", attachable, filename)
+        binding.pry
         blob.save! && upload(attachable)
         # :nocov:
         return if record.persisted? && !record.changed? && !record.save
@@ -38,6 +39,7 @@ module StorageTables
           blob.upload_without_unfurling(attachable)
         end
       rescue StandardError => e
+        binding.pry
         blob.destroy!
         raise e
       end

--- a/lib/storage_tables/errors.rb
+++ b/lib/storage_tables/errors.rb
@@ -5,4 +5,6 @@ module StorageTables
   class Error < StandardError; end
 
   class ServiceError < Error; end
+
+  class ActiveRecordError < Error; end
 end

--- a/lib/storage_tables/service.rb
+++ b/lib/storage_tables/service.rb
@@ -4,7 +4,7 @@ module StorageTables
   # Loads and configures the Storage service to be used to store files.
   class Service
     extend ActiveSupport::Autoload
-    autoload StorageTables::Service::Configuraator
+    autoload StorageTables::Service::Configurator
 
     class << self
       # Configure an Active Storage service by name from a set of configurations,

--- a/test/database/create_storage_tables_user_attachments_migration.rb
+++ b/test/database/create_storage_tables_user_attachments_migration.rb
@@ -19,10 +19,10 @@ class CreateStorageTablesUserAttachmentsMigration < ActiveRecord::Migration[7.1]
     SQL
 
     ActiveRecord::Base.connection.execute <<~SQL.squish
-      CREATE TRIGGER storage_tables_user_attachments_created AFTER INSERT ON storage_tables_user_avatar_attachments FOR EACH ROW EXECUTE FUNCTION increment_attachment_counter()
+      CREATE TRIGGER storage_tables_user_attachments_created AFTER INSERT ON storage_tables_user_avatar_attachments FOR EACH ROW EXECUTE FUNCTION public.increment_attachment_counter()
     SQL
     ActiveRecord::Base.connection.execute <<~SQL.squish
-      CREATE TRIGGER storage_tables_user_attachments_deleted AFTER INSERT ON storage_tables_user_avatar_attachments FOR EACH ROW EXECUTE FUNCTION decrement_attachment_counter()
+      CREATE TRIGGER storage_tables_user_attachments_deleted AFTER INSERT ON storage_tables_user_avatar_attachments FOR EACH ROW EXECUTE FUNCTION public.decrement_attachment_counter()
     SQL
   end
 

--- a/test/database/create_storage_tables_user_attachments_migration.rb
+++ b/test/database/create_storage_tables_user_attachments_migration.rb
@@ -22,7 +22,7 @@ class CreateStorageTablesUserAttachmentsMigration < ActiveRecord::Migration[7.1]
       CREATE TRIGGER storage_tables_user_attachments_created AFTER INSERT ON storage_tables_user_avatar_attachments FOR EACH ROW EXECUTE FUNCTION public.increment_attachment_counter()
     SQL
     ActiveRecord::Base.connection.execute <<~SQL.squish
-      CREATE TRIGGER storage_tables_user_attachments_deleted AFTER INSERT ON storage_tables_user_avatar_attachments FOR EACH ROW EXECUTE FUNCTION public.decrement_attachment_counter()
+      CREATE TRIGGER storage_tables_user_attachments_deleted AFTER DELETE ON storage_tables_user_avatar_attachments FOR EACH ROW EXECUTE FUNCTION public.decrement_attachment_counter()
     SQL
   end
 

--- a/test/dummy/db/structure.sql
+++ b/test/dummy/db/structure.sql
@@ -15,7 +15,7 @@ SET row_security = off;
 
 CREATE FUNCTION public.decrement_attachment_counter() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count - 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE checksum = NEW.checksum; RETURN NEW; END; $$;
+    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count - 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = OLD.blob_key AND checksum = OLD.checksum; RETURN OLD; END; $$;
 
 
 --
@@ -24,7 +24,7 @@ CREATE FUNCTION public.decrement_attachment_counter() RETURNS trigger
 
 CREATE FUNCTION public.increment_attachment_counter() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count + 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE checksum = NEW.checksum; RETURN NEW; END; $$;
+    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count + 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum; RETURN NEW; END; $$;
 
 
 SET default_tablespace = '';

--- a/test/dummy/db/structure.sql
+++ b/test/dummy/db/structure.sql
@@ -15,7 +15,7 @@ SET row_security = off;
 
 CREATE FUNCTION public.decrement_attachment_counter() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count - 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = OLD.blob_key AND checksum = OLD.checksum; RETURN OLD; END; $$;
+    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count - 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = OLD.blob_key AND checksum = OLD.checksum; RETURN NULL; END; $$;
 
 
 --
@@ -24,7 +24,7 @@ CREATE FUNCTION public.decrement_attachment_counter() RETURNS trigger
 
 CREATE FUNCTION public.increment_attachment_counter() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count + 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum; RETURN NEW; END; $$;
+    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count + 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum; RETURN NULL; END; $$;
 
 
 SET default_tablespace = '';

--- a/test/dummy/db/structure.sql
+++ b/test/dummy/db/structure.sql
@@ -15,7 +15,16 @@ SET row_security = off;
 
 CREATE FUNCTION public.decrement_attachment_counter() RETURNS trigger
     LANGUAGE plpgsql
-    AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count - 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = OLD.blob_key AND checksum = OLD.checksum; RETURN NULL; END; $$;
+    AS $$ DECLARE index integer; BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count - 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum; RETURN NULL; END; $$;
+
+
+--
+-- Name: immutable_blob_key_and_checksum(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.immutable_blob_key_and_checksum() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN IF NEW.checksum <> OLD.checksum THEN RAISE EXCEPTION 'updating checksum not allowed'; END IF; IF NEW.partition_key <> OLD.partition_key THEN RAISE EXCEPTION 'updating partition_key not allowed'; END IF; RETURN NEW; END; $$;
 
 
 --
@@ -25,6 +34,15 @@ CREATE FUNCTION public.decrement_attachment_counter() RETURNS trigger
 CREATE FUNCTION public.increment_attachment_counter() RETURNS trigger
     LANGUAGE plpgsql
     AS $$ BEGIN UPDATE storage_tables_blobs SET attachments_count = attachments_count + 1, attachments_count_modified = CURRENT_TIMESTAMP WHERE partition_key = NEW.blob_key AND checksum = NEW.checksum; RETURN NULL; END; $$;
+
+
+--
+-- Name: partition_keys(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.partition_keys() RETURNS text[]
+    LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+    AS $$ DECLARE list TEXT[] := '{A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,0,1,2,3,4,5,6,7,8,9,+,/}'; BEGIN RETURN list; END; $$;
 
 
 SET default_tablespace = '';
@@ -3149,6 +3167,454 @@ ALTER INDEX public.index_storage_tables_blobs_on_checksum ATTACH PARTITION publi
 --
 
 ALTER INDEX public.storage_tables_blobs_pkey ATTACH PARTITION public.storage_tables_blobs_partition_9_pkey;
+
+
+--
+-- Name: storage_tables_blobs_partition_0 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_0 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_1 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_1 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_10 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_10 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_11 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_11 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_12 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_12 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_13 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_13 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_14 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_14 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_15 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_15 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_16 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_16 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_17 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_17 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_18 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_18 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_19 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_19 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_2 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_2 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_20 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_20 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_21 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_21 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_22 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_22 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_23 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_23 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_24 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_24 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_25 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_25 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_26 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_26 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_27 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_27 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_28 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_28 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_29 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_29 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_3 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_3 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_30 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_30 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_31 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_31 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_32 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_32 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_33 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_33 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_34 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_34 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_35 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_35 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_36 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_36 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_37 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_37 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_38 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_38 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_39 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_39 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_4 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_4 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_40 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_40 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_41 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_41 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_42 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_42 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_43 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_43 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_44 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_44 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_45 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_45 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_46 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_46 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_47 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_47 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_48 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_48 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_49 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_49 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_5 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_5 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_50 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_50 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_51 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_51 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_52 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_52 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_53 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_53 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_54 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_54 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_55 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_55 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_56 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_56 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_57 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_57 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_58 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_58 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_59 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_59 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_6 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_6 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_60 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_60 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_61 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_61 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_62 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_62 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_63 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_63 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_7 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_7 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_8 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_8 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
+
+
+--
+-- Name: storage_tables_blobs_partition_9 immutable_blob_key_and_checksum; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER immutable_blob_key_and_checksum BEFORE UPDATE ON public.storage_tables_blobs_partition_9 FOR EACH ROW EXECUTE FUNCTION public.immutable_blob_key_and_checksum();
 
 
 --

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -80,9 +80,11 @@ module StorageTables
 
     test "creating a record with an existing blob attached" do
       user = User.create!(name: "New User")
-      user.avatar.attach create_blob, filename: "funky.jpg"
+      blob = create_blob
+      user.avatar.attach blob, filename: "funky.jpg"
 
       assert_predicate user.avatar, :attached?
+      assert_equal "funky.jpg", user.avatar.filename.to_s
     end
 
     test "creating a record with an existing blob from a signed ID attached" do
@@ -132,6 +134,16 @@ module StorageTables
 
         assert_equal "report.pdf", @user.avatar.filename.to_s
       end
+    end
+
+    test "when uploading fails, the attachment is not created" do
+      assert_raises(StandardError) do
+        StorageTables::Blob.stub :upload_without_unfurling, raise(StandardError) do
+          @user.avatar.attach(fixture_file_upload("racecar.jpg"), filename: "racecar.jpg")
+        end
+      end
+
+      assert_predicate @user.avatar, :blank?
     end
   end
 end

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -85,7 +85,7 @@ module StorageTables
 
       assert_predicate user.avatar, :attached?
       assert_equal "funky.jpg", user.avatar.filename.to_s
-      assert_equal 1, blob.attachments_count
+      assert_equal 1, blob.reload.attachments_count
     end
 
     test "creating a record with an existing blob from a signed ID attached" do

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -137,9 +137,11 @@ module StorageTables
     end
 
     test "when uploading fails, the attachment is not created" do
-      assert_raises(StandardError) do
-        StorageTables::Blob.stub :upload_without_unfurling, raise(StandardError) do
-          @user.avatar.attach(fixture_file_upload("racecar.jpg"), filename: "racecar.jpg")
+      assert_difference -> { StorageTables::Blob.count } do
+        assert_raises(StandardError) do
+          StorageTables::Blob.service.stub :upload, raise(StandardError) do
+            @user.avatar.attach(fixture_file_upload("racecar.jpg"), filename: "racecar.jpg")
+          end
         end
       end
 

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -137,9 +137,9 @@ module StorageTables
     end
 
     test "when uploading fails, the blob is not created" do
-      StorageTables::Blob.service.stub :upload, ->(*) { raise StandardError } do
+      StorageTables::Blob.service.stub :upload, ->(*) { raise ServiceError } do
         assert_no_difference -> { StorageTables::Blob.count } do
-          assert_raises StandardError do
+          assert_raises ServiceError do
             @user.avatar.attach(fixture_file_upload("racecar.jpg"), filename: "racecar.jpg")
           end
         end

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -145,5 +145,15 @@ module StorageTables
         end
       end
     end
+
+    test "when uploading fails, with a existing blob" do
+      blob = create_blob
+
+      StorageTables::Blob.service.stub :upload, ->(*) { raise ServiceError } do
+        assert_no_difference -> { StorageTables::Blob.count } do
+          @user.avatar.attach(blob, filename: "racecar.jpg")
+        end
+      end
+    end
   end
 end

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -136,16 +136,14 @@ module StorageTables
       end
     end
 
-    test "when uploading fails, the attachment is not created" do
-      assert_difference -> { StorageTables::Blob.count } do
-        assert_raises(StandardError) do
-          StorageTables::Blob.service.stub :upload, raise(StandardError) do
+    test "when uploading fails, the blob is not created" do
+      StorageTables::Blob.service.stub :upload, ->(*) { raise StandardError } do
+        assert_no_difference -> { StorageTables::Blob.count } do
+          assert_raises StandardError do
             @user.avatar.attach(fixture_file_upload("racecar.jpg"), filename: "racecar.jpg")
           end
         end
       end
-
-      assert_predicate @user.avatar, :blank?
     end
   end
 end

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -85,6 +85,7 @@ module StorageTables
 
       assert_predicate user.avatar, :attached?
       assert_equal "funky.jpg", user.avatar.filename.to_s
+      assert_equal 1, blob.attachments_count
     end
 
     test "creating a record with an existing blob from a signed ID attached" do

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -85,5 +85,22 @@ module StorageTables
       assert_predicate blob, :persisted?
       assert blob.service.exist?(blob.checksum)
     end
+
+    test "Destroying a blob also removes the file on disk" do
+      blob = create_blob
+      blob.destroy!
+
+      assert_not blob.service.exist?(blob.checksum)
+    end
+
+    test "Cannot destroy a blob that is referenced by an attachment" do
+      blob = create_blob
+      @user = User.create!(name: "My User")
+      @user.avatar.attach blob, filename: "funky.jpg"
+
+      assert_raises(ActiveRecord::InvalidForeignKey) do
+        blob.destroy!
+      end
+    end
   end
 end

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -4,14 +4,18 @@ require "test_helper"
 
 module StorageTables
   class BlobTest < ActiveSupport::TestCase
-    teardown do
-      StorageTables::Blob.delete_all
-    end
-
     test "setup" do
       blob = StorageTables::Blob.new
 
       assert_not blob.valid?
+    end
+
+    test "update checksum" do
+      blob = create_blob
+
+      assert_raises(ActiveRecord::StatementInvalid) do
+        blob.update!(checksum: "1234567890")
+      end
     end
 
     test "upload" do
@@ -98,8 +102,8 @@ module StorageTables
       @user = User.create!(name: "My User")
       @user.avatar.attach blob, filename: "funky.jpg"
 
-      assert_raises(ActiveRecord::InvalidForeignKey) do
-        blob.destroy!
+      assert_raises(StorageTables::ActiveRecordError) do
+        blob.reload.destroy!
       end
     end
   end


### PR DESCRIPTION
Attaching a file can fail in the after_commit on upload, which creates an attachment and a blob. 
In this PR I removed the after_commit hook and moved the upload to earlier in the process. In this scenario it will create the blob at first than upload the file, if this fails the blob will be removed.
If the attachment fails the blob can be reused at a later stage or will be removed by a periodic job.
