### PR TITLE
Get names from files and pathname

### DIFF
--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -38,7 +38,7 @@ module StorageTables
     end
 
     class << self
-      def build_after_unfurling(io:, content_type: nil, metadata: nil)
+      def build_after_unfurling(io:, content_type: nil, metadata: nil, filename: nil)
         checksum = compute_checksum_in_chunks(io)
         existing_blob = existing_blob(checksum)
 

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -38,7 +38,7 @@ module StorageTables
     end
 
     class << self
-      def build_after_unfurling(io:, content_type: nil, metadata: nil, filename: nil)
+      def build_after_unfurling(io:, content_type: nil, metadata: nil)
         checksum = compute_checksum_in_chunks(io)
         existing_blob = existing_blob(checksum)
 

--- a/lib/storage_tables/attachable/changes/create_one.rb
+++ b/lib/storage_tables/attachable/changes/create_one.rb
@@ -24,8 +24,8 @@ module StorageTables
         end
 
         def save
-          record.public_send("#{name}_storage_attachment=", attachment)
-          record.public_send("#{name}_storage_blob=", blob)
+          record.public_send(:"#{name}_storage_attachment=", attachment)
+          record.public_send(:"#{name}_storage_blob=", blob)
         end
 
         private
@@ -43,9 +43,9 @@ module StorageTables
         end
 
         def find_attachment
-          return unless record.public_send("#{name}_storage_blob") == blob
+          return unless record.public_send(:"#{name}_storage_blob") == blob
 
-          record.public_send("#{name}_storage_attachment")
+          record.public_send(:"#{name}_storage_attachment")
         end
 
         def find_or_build_blob
@@ -63,7 +63,7 @@ module StorageTables
               content_type: attachable.content_type
             )
           when Hash
-            StorageTables::Blob.build_after_unfurling(**attachable)
+            StorageTables::Blob.build_after_unfurling(**attachable.except(:filename))
           when String
             StorageTables::Blob.find_signed!(attachable)
           when File

--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -13,7 +13,7 @@ module StorageTables
             @storage_tables_attached[name.to_sym] ||= StorageTables::Attachable::One.new(name.to_s, self)
           end
 
-          define_method("#{name}=") do |attachable, filename|
+          define_method(:"#{name}=") do |attachable, filename|
             attachment_changes[name.to_s] =
               if attachable.nil? || attachable == ""
                 # TODO: Cover deleting attachments later.

--- a/lib/storage_tables/attachable/one.rb
+++ b/lib/storage_tables/attachable/one.rb
@@ -11,9 +11,11 @@ module StorageTables
       # record is next saved.
       #
       #   person.avatar.attach(params[:avatar]) # ActionDispatch::Http::UploadedFile object
-      #   person.avatar.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
+      #   person.avatar.attach(params[:signed_blob_id], filename: "Blob.file") # Signed reference to blob from direct upload
       #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpeg")
-      #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
+      #   person.avatar.attach(avatar_blob, filename: "Blob.file") # ActiveStorage::Blob object
+      #
+      # If the filename cannot be determined from the attachable, pass the filename as option: +filename+.
       def attach(attachable, filename: nil)
         filename ||= extract_filename(attachable)
 

--- a/lib/storage_tables/attachable/one.rb
+++ b/lib/storage_tables/attachable/one.rb
@@ -11,7 +11,7 @@ module StorageTables
       # record is next saved.
       #
       #   person.avatar.attach(params[:avatar]) # ActionDispatch::Http::UploadedFile object
-      #   person.avatar.attach(params[:signed_blob_id], filename: "Blob.file") # Signed reference to blob from direct upload
+      #   person.avatar.attach(params[:signed_blob_id], filename: "Blob.file") # Signed reference to blob
       #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpeg")
       #   person.avatar.attach(avatar_blob, filename: "Blob.file") # ActiveStorage::Blob object
       #

--- a/lib/storage_tables/attachable/one.rb
+++ b/lib/storage_tables/attachable/one.rb
@@ -19,7 +19,7 @@ module StorageTables
 
         raise ArgumentError, "Could not determine filename from #{attachable.inspect}" unless filename
 
-        record.public_send("#{name}=", attachable, filename)
+        record.public_send(:"#{name}=", attachable, filename)
         blob.save! && upload(attachable)
         # :nocov:
         return if record.persisted? && !record.changed? && !record.save
@@ -67,7 +67,7 @@ module StorageTables
         if change.present?
           change.attachment
         else
-          record.public_send("#{name}_storage_attachment")
+          record.public_send(:"#{name}_storage_attachment")
         end
       end
     end

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -15,7 +15,7 @@ module StorageTables
 
     test "creating a record with a File as attachable attribute" do
       @user = User.create!(name: "Dorian")
-      @user.avatar.attach file_fixture("racecar.jpg").open, filename: "racecar.jpg"
+      @user.avatar.attach file_fixture("racecar.jpg").open
 
       assert_equal "racecar.jpg", @user.avatar.filename.to_s
       assert_not_nil @user.avatar_storage_attachment
@@ -24,15 +24,15 @@ module StorageTables
 
     test "uploads the file when passing a File as attachable attribute" do
       @user = User.create!(name: "Dorian")
-      @user.avatar.attach file_fixture("racecar.jpg").open, filename: "racecar.jpg"
+      @user.avatar.attach file_fixture("racecar.jpg").open
 
       assert_nothing_raised { @user.avatar.download }
     end
 
     test "creating a record with an attachment where already one exists" do
-      @user.avatar.attach file_fixture("racecar.jpg").open, filename: "racecar.jpg"
+      @user.avatar.attach file_fixture("racecar.jpg").open
       @user2 = User.create!(name: "My User")
-      @user2.avatar.attach file_fixture("racecar.jpg").open, filename: "racecar.jpg"
+      @user2.avatar.attach file_fixture("racecar.jpg").open
 
       assert_equal @user.avatar_storage_blob, @user2.avatar_storage_blob
     end
@@ -41,6 +41,13 @@ module StorageTables
       @user.avatar.attach({ io: StringIO.new("STUFF"), content_type: "avatar/jpeg" }, filename: "town.jpg")
 
       assert_not_nil @user.avatar_storage_attachment
+    end
+
+    test "attaching a new blob from a Hash to an existing record with the filename in the hash" do
+      @user.avatar.attach({ io: StringIO.new("STUFF"), content_type: "avatar/jpeg", filename: "town.jpg" })
+
+      assert_not_nil @user.avatar_storage_attachment
+      assert_equal "town.jpg", @user.avatar_storage_attachment.filename
     end
 
     test "attaching StringIO attachable to an existing record" do
@@ -59,14 +66,14 @@ module StorageTables
         tempfile: fixture_file_upload("racecar.jpg")
       })
 
-      @user.avatar.attach upload, filename: "avatar.jpeg"
+      @user.avatar.attach upload
 
       assert_not_nil @user.avatar_storage_attachment
       assert_not_nil @user.avatar_storage_blob
     end
 
     test "creating a record with a Pathname as attachable attribute" do
-      @user.avatar.attach file_fixture("racecar.jpg"), filename: "racecar.jpg"
+      @user.avatar.attach file_fixture("racecar.jpg")
 
       assert_not_nil @user.avatar_storage_attachment
       assert_not_nil @user.avatar_storage_blob

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -35,7 +35,7 @@ module StorageTables
       blob2 = create_blob(data: "NewData")
       @user.avatar.attach(blob, filename: "test.txt")
 
-      assert_raises ActiveRecord::RecordNotSaved do
+      assert_raises ArgumentError do
         @user.avatar.attach(blob2, filename: nil)
       end
     end


### PR DESCRIPTION
Don't require filename to be send with attach for files or hashes. Because filename can be extracted from file or hash

fixes: #22 