### PR TITLE
Fix attachment setter method to handle nil filename

### DIFF
--- a/lib/storage_tables/attachable/changes.rb
+++ b/lib/storage_tables/attachable/changes.rb
@@ -6,6 +6,7 @@ module StorageTables
       extend ActiveSupport::Autoload
 
       eager_autoload do
+        autoload :Helper
         autoload :CreateOne
       end
     end

--- a/lib/storage_tables/attachable/changes/create_one.rb
+++ b/lib/storage_tables/attachable/changes/create_one.rb
@@ -11,7 +11,7 @@ module StorageTables
           @name = name
           @record = record
           @attachable = attachable
-          @filename = filename
+          @filename = filename || extract_filename(attachable)
           blob.identify_without_saving
         end
 
@@ -29,6 +29,21 @@ module StorageTables
         end
 
         private
+
+        def extract_filename(attachable)
+          case attachable
+          when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
+            attachable.original_filename
+          when Pathname
+            attachable.basename.to_s
+          when Hash
+            attachable.fetch(:filename)
+          when ActiveStorage::Blob
+            attachable.filename.to_s
+          when File
+            File.basename(attachable.path)
+          end
+        end
 
         def find_or_build_attachment
           find_attachment || build_attachment

--- a/lib/storage_tables/attachable/changes/create_one.rb
+++ b/lib/storage_tables/attachable/changes/create_one.rb
@@ -5,6 +5,8 @@ module StorageTables
     module Changes
       # Class used to create a new attachment from an attachable blob.
       class CreateOne
+        include Helper
+
         attr_reader :name, :record, :attachable, :filename
 
         def initialize(name, record, attachable, filename)
@@ -29,21 +31,6 @@ module StorageTables
         end
 
         private
-
-        def extract_filename(attachable)
-          case attachable
-          when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
-            attachable.original_filename
-          when Pathname
-            attachable.basename.to_s
-          when Hash
-            attachable.fetch(:filename)
-          when ActiveStorage::Blob
-            attachable.filename.to_s
-          when File
-            File.basename(attachable.path)
-          end
-        end
 
         def find_or_build_attachment
           find_attachment || build_attachment

--- a/lib/storage_tables/attachable/changes/helper.rb
+++ b/lib/storage_tables/attachable/changes/helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module StorageTables
+  module Attachable
+    module Changes
+      module Helper
+        def extract_filename(attachable)
+          case attachable
+          when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
+            attachable.original_filename
+          when Pathname
+            attachable.basename.to_s
+          when Hash
+            attachable.fetch(:filename)
+          when ActiveStorage::Blob
+            attachable.filename.to_s
+          when File
+            File.basename(attachable.path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/storage_tables/attachable/changes/helper.rb
+++ b/lib/storage_tables/attachable/changes/helper.rb
@@ -3,6 +3,7 @@
 module StorageTables
   module Attachable
     module Changes
+      # Helper methods for attachable changes.
       module Helper
         def extract_filename(attachable)
           case attachable

--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -13,7 +13,7 @@ module StorageTables
             @storage_tables_attached[name.to_sym] ||= StorageTables::Attachable::One.new(name.to_s, self)
           end
 
-          define_method(:"#{name}=") do |attachable, filename|
+          define_method(:"#{name}=") do |attachable, filename = nil|
             attachment_changes[name.to_s] =
               if attachable.nil? || attachable == ""
                 # TODO: Cover deleting attachments later.

--- a/lib/storage_tables/attachable/one.rb
+++ b/lib/storage_tables/attachable/one.rb
@@ -4,6 +4,8 @@ module StorageTables
   module Attachable
     # Representation of a single attachment to a model.
     class One < ActiveStorage::Attached::One
+      include Changes::Helper
+
       # Attaches an +attachable+ to the record.
       #
       # If the record is persisted and unchanged, the attachment is saved to
@@ -28,21 +30,6 @@ module StorageTables
         # :nocov:
 
         record.public_send(name.to_s)
-      end
-
-      def extract_filename(attachable)
-        case attachable
-        when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
-          attachable.original_filename
-        when Pathname
-          attachable.basename.to_s
-        when Hash
-          attachable.fetch(:filename)
-        when ActiveStorage::Blob
-          attachable.filename.to_s
-        when File
-          File.basename(attachable.path)
-        end
       end
 
       def upload(attachable)

--- a/lib/storage_tables/attached.rb
+++ b/lib/storage_tables/attached.rb
@@ -10,6 +10,6 @@ module StorageTables
   end
 end
 
+require "storage_tables/attachable/changes"
 require "storage_tables/attachable/model"
 require "storage_tables/attachable/one"
-require "storage_tables/attachable/changes"

--- a/lib/tasks/storage_tables_tasks.rake
+++ b/lib/tasks/storage_tables_tasks.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # desc "Explaining what the task does"
 # task :storage_tables do
 #   # Task goes here

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -29,11 +29,11 @@ module StorageTables
       assert_nothing_raised { @user.avatar.download }
     end
 
-    test "uploads the file when set through set statement" do
-      @user = User.create!(name: "Dorian")
-      @user.avatar = file_fixture("racecar.jpg").open
+    test "uploads the file when set through setter and set filename seperate" do
+      @user.avatar = file_fixture("racecar.jpg")
+      @user.avatar.filename = "racecar.jpg"
 
-      assert_nothing_raised { @user.avatar.download }
+      assert_nothing_raised { @user.save! }
       assert_equal "racecar.jpg", @user.avatar.filename.to_s
     end
 

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -35,7 +35,7 @@ module StorageTables
       assert_nothing_raised { @user.save! }
       assert_equal "racecar.jpg", @user.avatar.filename.to_s
     end
-    
+
     test "uploads the file when set through setter and set filename seperate" do
       @user.avatar = file_fixture("racecar.jpg")
       @user.avatar.filename = "racecar.jpg"

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -29,6 +29,13 @@ module StorageTables
       assert_nothing_raised { @user.avatar.download }
     end
 
+    test "uploads the file when set through setter" do
+      @user.avatar = file_fixture("racecar.jpg")
+
+      assert_nothing_raised { @user.save! }
+      assert_equal "racecar.jpg", @user.avatar.filename.to_s
+    end
+    
     test "uploads the file when set through setter and set filename seperate" do
       @user.avatar = file_fixture("racecar.jpg")
       @user.avatar.filename = "racecar.jpg"

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -34,6 +34,7 @@ module StorageTables
       @user.avatar = file_fixture("racecar.jpg").open
 
       assert_nothing_raised { @user.avatar.download }
+      assert_equal "racecar.jpg", @user.avatar.filename.to_s
     end
 
     test "create a record with a ActiveStorage::Blob as attachable attribute" do

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -29,6 +29,13 @@ module StorageTables
       assert_nothing_raised { @user.avatar.download }
     end
 
+    test "uploads the file when set through set statement" do
+      @user = User.create!(name: "Dorian")
+      @user.avatar = file_fixture("racecar.jpg").open
+
+      assert_nothing_raised { @user.avatar.download }
+    end
+
     test "create a record with a ActiveStorage::Blob as attachable attribute" do
       blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new("STUFF"), content_type: "avatar/jpeg",
                                                     filename: "town.jpg")


### PR DESCRIPTION
Allow a nil to setter for attachable. Now it is not possible to use `attachment=`, only to use `.attach`. The attach method uses an autosave, so is not always the ideal method to use.

## For reviewer

Change in storage_tables.rake is to fix rubocop check.
File is deleted in: https://github.com/payt/storage_tables/pull/17