### PR TITLE
Add path method to Attachment model

### DIFF
--- a/app/models/storage_tables/attachment.rb
+++ b/app/models/storage_tables/attachment.rb
@@ -12,11 +12,15 @@ module StorageTables
     validates :filename, presence: true
 
     def download
-      association(:blob).klass.service.download("#{blob_key}#{checksum}==")
+      association(:blob).klass.service.download(full_checksum)
     end
 
     def path
-      association(:blob).klass.service.path_for(checksum)
+      association(:blob).klass.service.path_for(full_checksum)
+    end
+
+    def full_checksum
+      "#{blob_key}#{checksum}=="
     end
   end
 end

--- a/app/models/storage_tables/attachment.rb
+++ b/app/models/storage_tables/attachment.rb
@@ -14,5 +14,9 @@ module StorageTables
     def download
       association(:blob).klass.service.download("#{blob_key}#{checksum}==")
     end
+
+    def path
+      association(:blob).klass.service.path_for(checksum)
+    end
   end
 end

--- a/lib/storage_tables/service/disk_service.rb
+++ b/lib/storage_tables/service/disk_service.rb
@@ -6,8 +6,6 @@ module StorageTables
   module Service
     # Local disk storage service.
     class DiskService < ActiveStorage::Service::DiskService
-      private
-
       def path_for(checksum) # :nodoc:
         # Replace the forward slash with an underscore
         # Replace the plus sign with a minus sign
@@ -15,6 +13,8 @@ module StorageTables
 
         File.join root, folder_for(checksum), checksum
       end
+
+      private
 
       def folder_for(checksum)
         "#{checksum[0]}/#{checksum[1..2]}/#{checksum[3..4]}"

--- a/lib/storage_tables/service/disk_service.rb
+++ b/lib/storage_tables/service/disk_service.rb
@@ -9,9 +9,9 @@ module StorageTables
       def path_for(checksum) # :nodoc:
         # Replace the forward slash with an underscore
         # Replace the plus sign with a minus sign
-        checksum = checksum.tr("/+", "_-")
+        refactored_checksum = checksum.tr("/+", "_-")
 
-        File.join root, folder_for(checksum), checksum
+        File.join root, folder_for(refactored_checksum), refactored_checksum
       end
 
       private

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -94,7 +94,6 @@ module StorageTables
     test "can create a path from attachment without touching a blob" do
       attachment = UserAvatarAttachment.new(checksum: "123456")
 
-      assert attachment.path.start_with?("/tmp/storage_tables_tests")
       assert attachment.path.end_with?(attachment.checksum.tr("/+", "_-"))
     end
 

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -91,6 +91,13 @@ module StorageTables
       assert_equal @user, findable
     end
 
+    test "can create a path from attachment without touching a blob" do
+      attachment = UserAvatarAttachment.new(checksum: "123456")
+
+      assert attachment.path.start_with?("/tmp/storage_tables_tests")
+      assert attachment.path.end_with?(attachment.checksum.tr("/+", "_-"))
+    end
+
     private
 
     def assert_blob_identified_before_owner_validated(owner, blob, content_type)

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -91,10 +91,19 @@ module StorageTables
       assert_equal @user, findable
     end
 
-    test "can create a path from attachment without touching a blob" do
-      attachment = UserAvatarAttachment.new(checksum: "123456")
+    test "path can be created through the attachment" do
+      attachment = @user.avatar.attach({ io: StringIO.new("STUFF"), content_type: "avatar/jpeg" }, filename: "town.jpg")
 
-      assert attachment.path.end_with?(attachment.checksum.tr("/+", "_-"))
+      assert_path_exists attachment.path
+    end
+
+    test "can create a path from attachment without touching a blob" do
+      attachment = UserAvatarAttachment.new(checksum: "123456", blob_key: "a")
+      full_checksum = attachment.full_checksum
+
+      expected_path = "#{full_checksum[0]}/#{full_checksum[1..2]}/#{full_checksum[3..4]}/#{full_checksum}"
+
+      assert attachment.path.end_with?(expected_path)
     end
 
     private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,7 +29,7 @@ end
 require "tmpdir"
 
 Rails.configuration.active_storage.service_configurations = SERVICE_CONFIGURATIONS.merge(
-  "local" => { "service" => "Disk", "root" => Dir.mktmpdir("active_storage_tests") }
+  "local" => { "service" => "Disk", "root" => Dir.mktmpdir("storage_tables_tests") }
 ).deep_stringify_keys
 
 Rails.configuration.active_storage.service = "local"


### PR DESCRIPTION
fixes: #23

Add a path method to attachment so it can easily get a path, without checking on the blob.