### PR TITLE
Make it possible to delete an attachment

### DIFF
--- a/app/models/storage_tables/attachment.rb
+++ b/app/models/storage_tables/attachment.rb
@@ -7,7 +7,7 @@ module StorageTables
 
     belongs_to :blob, class_name: "StorageTables::Blob", autosave: true, query_constraints: [:checksum, :blob_key]
 
-    delegate :signed_id, to: :blob
+    delegate :byte_size, to: :blob
 
     validates :filename, presence: true
 

--- a/app/models/storage_tables/attachment.rb
+++ b/app/models/storage_tables/attachment.rb
@@ -7,7 +7,7 @@ module StorageTables
 
     belongs_to :blob, class_name: "StorageTables::Blob", autosave: true, query_constraints: [:checksum, :blob_key]
 
-    delegate :byte_size, to: :blob
+    delegate :byte_size, :content_type, to: :blob
 
     validates :filename, presence: true
 

--- a/lib/storage_tables/attachable/changes.rb
+++ b/lib/storage_tables/attachable/changes.rb
@@ -8,6 +8,7 @@ module StorageTables
       eager_autoload do
         autoload :Helper
         autoload :CreateOne
+        autoload :DeleteOne
       end
     end
   end

--- a/lib/storage_tables/attachable/changes/delete_one.rb
+++ b/lib/storage_tables/attachable/changes/delete_one.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module StorageTables
+  module Attachable
+    module Changes
+      class DeleteOne < ActiveStorage::Attached::Changes::DeleteOne # :nodoc:
+        attr_reader :name, :record
+
+        def save
+          record.public_send("#{name}_storage_attachment=", nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/storage_tables/attachable/changes/delete_one.rb
+++ b/lib/storage_tables/attachable/changes/delete_one.rb
@@ -4,10 +4,8 @@ module StorageTables
   module Attachable
     module Changes
       class DeleteOne < ActiveStorage::Attached::Changes::DeleteOne # :nodoc:
-        attr_reader :name, :record
-
         def save
-          record.public_send("#{name}_storage_attachment=", nil)
+          record.public_send(:"#{name}_storage_attachment=", nil)
         end
       end
     end

--- a/lib/storage_tables/attachable/changes/delete_one.rb
+++ b/lib/storage_tables/attachable/changes/delete_one.rb
@@ -5,7 +5,7 @@ module StorageTables
     module Changes
       class DeleteOne < ActiveStorage::Attached::Changes::DeleteOne # :nodoc:
         def save
-          record.public_send(:"#{name}_storage_attachment=", nil)
+          record.public_send(:"#{name}_storage_attachment").delete
         end
       end
     end

--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -16,7 +16,6 @@ module StorageTables
           define_method(:"#{name}=") do |attachable, filename = nil|
             attachment_changes[name.to_s] =
               if attachable.nil? || attachable == ""
-                # TODO: Cover deleting attachments later.
                 StorageTables::Attachable::Changes::DeleteOne.new(name.to_s, self)
               else
                 StorageTables::Attachable::Changes::CreateOne.new(name.to_s, self, attachable, filename)
@@ -24,7 +23,7 @@ module StorageTables
           end
 
           has_one :"#{name}_storage_attachment", class_name: class_name.to_s, inverse_of: :record,
-                                                 foreign_key: :record_id, dependent: :destroy
+                                                 foreign_key: :record_id
           has_one :"#{name}_storage_blob", through: :"#{name}_storage_attachment", class_name: "StorageTables::Blob",
                                            source: :blob
 

--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -17,16 +17,14 @@ module StorageTables
             attachment_changes[name.to_s] =
               if attachable.nil? || attachable == ""
                 # TODO: Cover deleting attachments later.
-                # :nocov:
-                ActiveStorage::Attached::Changes::DeleteOne.new(name.to_s, self)
-                # :nocov:
+                StorageTables::Attachable::Changes::DeleteOne.new(name.to_s, self)
               else
                 StorageTables::Attachable::Changes::CreateOne.new(name.to_s, self, attachable, filename)
               end
           end
 
           has_one :"#{name}_storage_attachment", class_name: class_name.to_s, inverse_of: :record,
-                                                 foreign_key: :record_id
+                                                 foreign_key: :record_id, dependent: :destroy
           has_one :"#{name}_storage_blob", through: :"#{name}_storage_attachment", class_name: "StorageTables::Blob",
                                            source: :blob
 

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -106,6 +106,18 @@ module StorageTables
       assert attachment.path.end_with?(expected_path)
     end
 
+    test "set a attachment to nil" do
+      blob = create_blob(data: "NewData")
+
+      @user.avatar.attach(blob, filename: "test.txt")
+
+      @user.update(avatar: nil)
+
+      assert_not_predicate @user.avatar, :present?
+      assert_equal 0, blob.attachments_count
+      assert_predicate blob, :persisted?
+    end
+
     private
 
     def assert_blob_identified_before_owner_validated(owner, blob, content_type)

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -111,10 +111,9 @@ module StorageTables
 
       @user.avatar.attach(blob, filename: "test.txt")
 
-      @user.update(avatar: nil)
+      @user.update!(avatar: nil)
 
       assert_not_predicate @user.avatar, :present?
-      assert_equal 0, blob.attachments_count
       assert_predicate blob, :persisted?
     end
 


### PR DESCRIPTION
Add the delete method for a single attachment

## For reviewer

- The signed_id is not needed for delegation to the blob as signed_id for a blob could be created from the attachment
- The byte_size and content_type can be collected from the blob