### PR TITLE
Add filename method to Attachment model

### DIFF
--- a/app/models/storage_tables/attachment.rb
+++ b/app/models/storage_tables/attachment.rb
@@ -22,5 +22,12 @@ module StorageTables
     def full_checksum
       "#{blob_key}#{checksum}=="
     end
+
+    # Returns an ActiveStorage::Filename instance of the filename that can be
+    # queried for basename, extension, and a sanitized version of the filename
+    # that's safe to use in URLs.
+    def filename
+      ActiveStorage::Filename.new(self[:filename])
+    end
   end
 end

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -51,7 +51,7 @@ module StorageTables
       @user.avatar.attach blob
 
       assert_not_nil @user.avatar_storage_attachment
-      assert_equal "town.jpg", @user.avatar_storage_attachment.filename
+      assert_equal "town.jpg", @user.avatar_storage_attachment.filename.to_s
     end
 
     test "creating a record with an attachment where already one exists" do
@@ -72,7 +72,7 @@ module StorageTables
       @user.avatar.attach({ io: StringIO.new("STUFF"), content_type: "avatar/jpeg", filename: "town.jpg" })
 
       assert_not_nil @user.avatar_storage_attachment
-      assert_equal "town.jpg", @user.avatar_storage_attachment.filename
+      assert_equal "town.jpg", @user.avatar_storage_attachment.filename.to_s
     end
 
     test "attaching StringIO attachable to an existing record" do


### PR DESCRIPTION
Extend filename of attachment with `ActiveStorage::Filename` so we can use the methods like `extension` etc.