### PR TITLE
Fix not uploading when assigning to object

### DIFF
--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -94,6 +94,9 @@ module StorageTables
 
     def upload_without_unfurling(io)
       service.upload checksum, io, checksum:, **service_metadata
+    rescue StorageTables::ServiceError => e
+      destroy!
+      raise e
     end
 
     # Downloads the file associated with this blob. If no block is given,

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -92,6 +92,8 @@ module StorageTables
       self.identified = true
     end
 
+    # Uploads the file associated with this blob to the service.
+    # When uploading fails the blob is deleted from the database, as it is not usable.
     def upload_without_unfurling(io)
       service.upload checksum, io, checksum:, **service_metadata
     rescue StorageTables::ServiceError => e

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -96,9 +96,9 @@ module StorageTables
     # When uploading fails the blob is deleted from the database, as it is not usable.
     def upload_without_unfurling(io)
       service.upload checksum, io, checksum:, **service_metadata
-    rescue StorageTables::ServiceError => e
+    rescue StorageTables::ServiceError
       destroy!
-      raise e
+      raise
     end
 
     # Downloads the file associated with this blob. If no block is given,

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -45,6 +45,17 @@ module StorageTables
       assert StorageTables::Blob.service.exist?(@user.avatar.full_checksum)
     end
 
+    test "when assigning a empty blob it cannot save" do
+      @user.avatar = Blob.new(byte_size: 0, checksum: Digest::MD5.base64digest(""))
+      @user.avatar.filename = "racecar.jpg"
+
+      error = assert_raises(StorageTables::ActiveRecordError) do
+        @user.save!
+      end
+
+      assert_equal "File is not yet uploaded", error.message
+    end
+
     test "create a record with a ActiveStorage::Blob as attachable attribute" do
       blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new("STUFF"), content_type: "avatar/jpeg",
                                                     filename: "town.jpg")

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -42,6 +42,7 @@ module StorageTables
 
       assert_nothing_raised { @user.save! }
       assert_equal "racecar.jpg", @user.avatar.filename.to_s
+      assert StorageTables::Blob.service.exist?(@user.avatar.full_checksum)
     end
 
     test "create a record with a ActiveStorage::Blob as attachable attribute" do


### PR DESCRIPTION
When files were set through their model like: `@user.avatar = file` the file was not uploaded on save!
With the current setup this was also not possible as we can't upload a file in a transaction.

Suggestion to fix is uploading the file on assigning. So when calling `save!` the blob is already persisted