### PR TITLE
Add on_disk? method to Blob model

### DIFF
--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -37,6 +37,11 @@ module StorageTables
       super
     end
 
+    # Check if file exists on disk
+    def on_disk?
+      service.exist?(checksum)
+    end
+
     class << self
       def build_after_unfurling(io:, content_type: nil, metadata: nil)
         checksum = compute_checksum_in_chunks(io)

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -23,7 +23,7 @@ module StorageTables
 
       assert_predicate(blob, :persisted?)
       # Check that the blob was uploaded to the service.
-      assert blob.service.exist?(blob.checksum)
+      assert_predicate blob, :on_disk?
     end
 
     test "identify without byte size" do
@@ -37,7 +37,7 @@ module StorageTables
 
       assert_predicate(blob, :persisted?)
       # Check that the blob was uploaded to the service.
-      assert blob.service.exist?(blob.checksum)
+      assert_predicate blob, :on_disk?
     end
 
     test "create_and_upload extracts content type from data" do
@@ -87,7 +87,7 @@ module StorageTables
       blob = create_blob(content_type: "text/html")
 
       assert_predicate blob, :persisted?
-      assert blob.service.exist?(blob.checksum)
+      assert_predicate blob, :on_disk?
     end
 
     test "Destroying a blob also removes the file on disk" do


### PR DESCRIPTION
The Blob model has been updated with a new method called on_disk?. This method checks if the file exists on disk by calling the exist? method on the service with the checksum as the argument. 