### PR TITLE
Add from_hash method to StorageTables::Attachable::Changes::CreateOne

### DIFF
--- a/lib/storage_tables/attachable/changes/create_one.rb
+++ b/lib/storage_tables/attachable/changes/create_one.rb
@@ -102,7 +102,7 @@ module StorageTables
 
         def from_hash(attachable)
           return attachable[:blob] if attachable[:blob]
-          return StorageTables::Blob.find_by_checksum(attachable[:checksum]) if attachable[:checksum]
+          return StorageTables::Blob.find_by_checksum!(attachable[:checksum]) if attachable[:checksum]
 
           StorageTables::Blob.create_and_upload!(**attachable.except(:filename))
         end

--- a/lib/storage_tables/attachable/changes/create_one.rb
+++ b/lib/storage_tables/attachable/changes/create_one.rb
@@ -82,7 +82,7 @@ module StorageTables
               content_type: attachable.content_type
             )
           when Hash
-            StorageTables::Blob.create_and_upload!(**attachable.except(:filename))
+            from_hash(attachable)
           when String
             StorageTables::Blob.find_signed!(attachable)
           when File
@@ -98,6 +98,13 @@ module StorageTables
               "got #{attachable.inspect}"
             )
           end
+        end
+
+        def from_hash(attachable)
+          return attachable[:blob] if attachable[:blob]
+          return StorageTables::Blob.find_by_checksum(attachable[:checksum]) if attachable[:checksum]
+
+          StorageTables::Blob.create_and_upload!(**attachable.except(:filename))
         end
       end
     end

--- a/test/models/attached/one_test.rb
+++ b/test/models/attached/one_test.rb
@@ -91,6 +91,45 @@ module StorageTables
       assert_equal "town.jpg", @user.avatar_storage_attachment.filename.to_s
     end
 
+    test "attach a existing blob from a Hash with the blob key" do
+      blob = create_blob
+      @user.avatar.attach({ io: StringIO.new("STUFF"), content_type: "avatar/jpeg", filename: "town.jpg", blob: })
+
+      assert_not_nil @user.avatar_storage_attachment
+      assert_equal "town.jpg", @user.avatar_storage_attachment.filename.to_s
+      assert_equal blob, @user.avatar_storage_blob
+    end
+
+    test "attach a existing blob from a Hash with the cehcksum key" do
+      blob = create_blob
+      @user.avatar.attach({ io: StringIO.new("STUFF"), content_type: "avatar/jpeg", filename: "town.jpg",
+                            checksum: blob.checksum })
+
+      assert_not_nil @user.avatar_storage_attachment
+      assert_equal "town.jpg", @user.avatar_storage_attachment.filename.to_s
+      assert_equal blob, @user.avatar_storage_blob
+    end
+
+    test "assign an existing blob from a Hash with the blob key" do
+      blob = create_blob
+      @user.avatar = { filename: "town.jpg", blob: }
+      @user.save!
+
+      assert_not_nil @user.avatar_storage_attachment
+      assert_equal "town.jpg", @user.avatar_storage_attachment.filename.to_s
+      assert_equal blob, @user.avatar_storage_blob
+    end
+
+    test "assign an existing blob from a Hash with the cehcksum key" do
+      blob = create_blob
+      @user.avatar = { filename: "town.jpg", checksum: blob.checksum }
+      @user.save!
+
+      assert_not_nil @user.avatar_storage_attachment
+      assert_equal "town.jpg", @user.avatar_storage_attachment.filename.to_s
+      assert_equal blob, @user.avatar_storage_blob
+    end
+
     test "attaching StringIO attachable to an existing record" do
       upload = Rack::Test::UploadedFile.new StringIO.new(""), original_filename: "test.txt"
 


### PR DESCRIPTION
This commit adds a new method called from_hash to the StorageTables::Attachable::Changes::CreateOne module. The from_hash method is responsible for handling the creation of a new blob based on the attachable data provided as a hash. It checks if the attachable data contains a :blob key or a :checksum key, and performs the appropriate action accordingly. This change improves the flexibility and usability of the CreateOne module.