### PR TITLE
Detach the disk service from ActiveStorage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,10 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - test/**/*
+
 Metrics/CyclomaticComplexity:
   Max: 15
 

--- a/lib/storage_tables/engine.rb
+++ b/lib/storage_tables/engine.rb
@@ -3,7 +3,6 @@
 require "rails/engine"
 
 require "storage_tables"
-
 require "storage_tables/service/registry"
 require "storage_tables/reflection"
 

--- a/lib/storage_tables/engine.rb
+++ b/lib/storage_tables/engine.rb
@@ -3,6 +3,7 @@
 require "rails/engine"
 
 require "storage_tables"
+
 require "storage_tables/service/registry"
 require "storage_tables/reflection"
 

--- a/lib/storage_tables/errors.rb
+++ b/lib/storage_tables/errors.rb
@@ -11,4 +11,6 @@ module StorageTables
   # Raised when uploaded or downloaded data does not match a precomputed checksum.
   # Indicates that a network error or a software bug caused data corruption.
   class IntegrityError < Error; end
+
+  class FileNotFoundError < Error; end
 end

--- a/lib/storage_tables/service.rb
+++ b/lib/storage_tables/service.rb
@@ -21,7 +21,7 @@ module StorageTables
       # Passes the configurator and all of the service's config as keyword args.
       #
       # See MirrorService for an example.
-      def build(name:, service: nil, **service_config) # :nodoc:
+      def build(name:, **service_config) # :nodoc:
         new(**service_config).tap do |service_instance|
           service_instance.name = name
         end
@@ -69,9 +69,9 @@ module StorageTables
     end
 
     # Returns the URL for the file at the +checksum+. This returns a permanent URL for public files, and returns a
-    # short-lived URL for private files. For private files you can provide the +disposition+ (+:inline+ or +:attachment+),
-    # +filename+, and +content_type+ that you wish the file to be served with on request. Additionally, you can also provide
-    # the amount of seconds the URL will be valid for, specified in +expires_in+.
+    # short-lived URL for private files. For private files you can provide the +disposition+ (+:inline+ or
+    # +:attachment+), +filename+, and +content_type+ that you wish the file to be served with on request. Additionally,
+    # you can also provide the amount of seconds the URL will be valid for, specified in +expires_in+.
     def url(checksum, **options)
       instrument(:url, checksum:) do |payload|
         generated_url =

--- a/lib/storage_tables/service.rb
+++ b/lib/storage_tables/service.rb
@@ -29,7 +29,7 @@ module StorageTables
     end
 
     # Upload the +io+ to the +key+ specified. If a +checksum+ is provided, the service will
-    # ensure a match when the upload has completed or raise an ActiveStorage::IntegrityError.
+    # ensure a match when the upload has completed or raise an StorageTables::IntegrityError.
     def upload(checksum, io, **options)
       raise NotImplementedError
     end

--- a/lib/storage_tables/service.rb
+++ b/lib/storage_tables/service.rb
@@ -21,7 +21,7 @@ module StorageTables
       # Passes the configurator and all of the service's config as keyword args.
       #
       # See MirrorService for an example.
-      def build(configurator:, name:, service: nil, **service_config) # :nodoc:
+      def build(name:, service: nil, **service_config) # :nodoc:
         new(**service_config).tap do |service_instance|
           service_instance.name = name
         end
@@ -30,22 +30,22 @@ module StorageTables
 
     # Upload the +io+ to the +key+ specified. If a +checksum+ is provided, the service will
     # ensure a match when the upload has completed or raise an ActiveStorage::IntegrityError.
-    def upload(key, io, checksum: nil, **options)
+    def upload(checksum, io, **options)
       raise NotImplementedError
     end
 
     # Update metadata for the file identified by +key+ in the service.
     # Override in subclasses only if the service needs to store specific
     # metadata that has to be updated upon identification.
-    def update_metadata(key, **metadata); end
+    def update_metadata(checksum, **metadata); end
 
     # Return the content of the file at the +key+.
-    def download(key)
+    def download(checksum)
       raise NotImplementedError
     end
 
     # Return the partial content in the byte +range+ of the file at the +key+.
-    def download_chunk(key, range)
+    def download_chunk(checksum, range)
       raise NotImplementedError
     end
 
@@ -54,36 +54,31 @@ module StorageTables
     end
 
     # Concatenate multiple files into a single "composed" file.
-    def compose(source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
+    def compose(*)
       raise NotImplementedError
     end
 
     # Delete the file at the +key+.
-    def delete(key)
-      raise NotImplementedError
-    end
-
-    # Delete files at keys starting with the +prefix+.
-    def delete_prefixed(prefix)
+    def delete(checksum)
       raise NotImplementedError
     end
 
     # Return +true+ if a file exists at the +key+.
-    def exist?(key)
+    def exist?(checksum)
       raise NotImplementedError
     end
 
-    # Returns the URL for the file at the +key+. This returns a permanent URL for public files, and returns a
+    # Returns the URL for the file at the +checksum+. This returns a permanent URL for public files, and returns a
     # short-lived URL for private files. For private files you can provide the +disposition+ (+:inline+ or +:attachment+),
     # +filename+, and +content_type+ that you wish the file to be served with on request. Additionally, you can also provide
     # the amount of seconds the URL will be valid for, specified in +expires_in+.
-    def url(key, **options)
-      instrument(:url, key:) do |payload|
+    def url(checksum, **options)
+      instrument(:url, checksum:) do |payload|
         generated_url =
           if public?
-            public_url(key, **options)
+            public_url(checksum, **options)
           else
-            private_url(key, **options)
+            private_url(checksum, **options)
           end
 
         payload[:url] = generated_url
@@ -92,16 +87,16 @@ module StorageTables
       end
     end
 
-    # Returns a signed, temporary URL that a direct upload file can be PUT to on the +key+.
+    # Returns a signed, temporary URL that a direct upload file can be PUT to on the +checksum+.
     # The URL will be valid for the amount of seconds specified in +expires_in+.
     # You must also provide the +content_type+, +content_length+, and +checksum+ of the file
     # that will be uploaded. All these attributes will be validated by the service upon upload.
-    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:, custom_metadata: {})
+    def url_for_direct_upload(*)
       raise NotImplementedError
     end
 
     # Returns a Hash of headers for +url_for_direct_upload+ requests.
-    def headers_for_direct_upload(_key, filename:, content_type:, content_length:, checksum:, custom_metadata: {})
+    def headers_for_direct_upload(*)
       {}
     end
 
@@ -114,7 +109,7 @@ module StorageTables
     def instrument(operation, payload = {}, &)
       ActiveSupport::Notifications.instrument(
         "service_#{operation}.storage_tables",
-        payload.merge(service: service_name), &
+        payload, &
       )
     end
   end

--- a/lib/storage_tables/service.rb
+++ b/lib/storage_tables/service.rb
@@ -4,25 +4,118 @@ module StorageTables
   # Loads and configures the Storage service to be used to store files.
   class Service
     extend ActiveSupport::Autoload
-
-    autoload StorageTables::Service::Configurator
+    autoload :Configurator
+    attr_accessor :name
 
     class << self
       # Configure an Active Storage service by name from a set of configurations,
       # typically loaded from a YAML file. The Active Storage engine uses this
       # to set the global Active Storage service when the app boots.
       def configure(service_name, configurations)
-        StorageTables::Service::Configurator.build(service_name, configurations)
+        Configurator.build(service_name, configurations)
       end
 
-      private
-
-      def instrument(operation, payload = {}, &)
-        ActiveSupport::Notifications.instrument(
-          "service_#{operation}.storage_tables",
-          payload.merge(service: service_name), &
-        )
+      # Override in subclasses that stitch together multiple services and hence
+      # need to build additional services using the configurator.
+      #
+      # Passes the configurator and all of the service's config as keyword args.
+      #
+      # See MirrorService for an example.
+      def build(configurator:, name:, service: nil, **service_config) # :nodoc:
+        new(**service_config).tap do |service_instance|
+          service_instance.name = name
+        end
       end
+    end
+
+    # Upload the +io+ to the +key+ specified. If a +checksum+ is provided, the service will
+    # ensure a match when the upload has completed or raise an ActiveStorage::IntegrityError.
+    def upload(key, io, checksum: nil, **options)
+      raise NotImplementedError
+    end
+
+    # Update metadata for the file identified by +key+ in the service.
+    # Override in subclasses only if the service needs to store specific
+    # metadata that has to be updated upon identification.
+    def update_metadata(key, **metadata); end
+
+    # Return the content of the file at the +key+.
+    def download(key)
+      raise NotImplementedError
+    end
+
+    # Return the partial content in the byte +range+ of the file at the +key+.
+    def download_chunk(key, range)
+      raise NotImplementedError
+    end
+
+    def open(...)
+      ActiveStorage::Downloader.new(self).open(...)
+    end
+
+    # Concatenate multiple files into a single "composed" file.
+    def compose(source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
+      raise NotImplementedError
+    end
+
+    # Delete the file at the +key+.
+    def delete(key)
+      raise NotImplementedError
+    end
+
+    # Delete files at keys starting with the +prefix+.
+    def delete_prefixed(prefix)
+      raise NotImplementedError
+    end
+
+    # Return +true+ if a file exists at the +key+.
+    def exist?(key)
+      raise NotImplementedError
+    end
+
+    # Returns the URL for the file at the +key+. This returns a permanent URL for public files, and returns a
+    # short-lived URL for private files. For private files you can provide the +disposition+ (+:inline+ or +:attachment+),
+    # +filename+, and +content_type+ that you wish the file to be served with on request. Additionally, you can also provide
+    # the amount of seconds the URL will be valid for, specified in +expires_in+.
+    def url(key, **options)
+      instrument(:url, key:) do |payload|
+        generated_url =
+          if public?
+            public_url(key, **options)
+          else
+            private_url(key, **options)
+          end
+
+        payload[:url] = generated_url
+
+        generated_url
+      end
+    end
+
+    # Returns a signed, temporary URL that a direct upload file can be PUT to on the +key+.
+    # The URL will be valid for the amount of seconds specified in +expires_in+.
+    # You must also provide the +content_type+, +content_length+, and +checksum+ of the file
+    # that will be uploaded. All these attributes will be validated by the service upon upload.
+    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:, custom_metadata: {})
+      raise NotImplementedError
+    end
+
+    # Returns a Hash of headers for +url_for_direct_upload+ requests.
+    def headers_for_direct_upload(_key, filename:, content_type:, content_length:, checksum:, custom_metadata: {})
+      {}
+    end
+
+    def public?
+      @public
+    end
+
+    private
+
+    def instrument(operation, payload = {}, &)
+      ActiveSupport::Notifications.instrument(
+        "service_#{operation}.storage_tables",
+        payload.merge(service: service_name), &
+      )
     end
   end
 end

--- a/lib/storage_tables/service/configurator.rb
+++ b/lib/storage_tables/service/configurator.rb
@@ -6,7 +6,9 @@ require "active_storage/service/configurator"
 module StorageTables
   class Service
     # Set the storage service to be used by Storage Tables.
-    class Configurator < ActiveStorage::Service::Configurator
+    class Configurator
+      attr_reader :configurations
+
       def self.build(service_name, configurations)
         new(configurations).build(service_name)
       end
@@ -23,6 +25,12 @@ module StorageTables
       end
 
       private
+
+      def config_for(name)
+        configurations.fetch name do
+          raise "Missing configuration for the #{name.inspect} Storage Storage service. Configurations available for #{configurations.keys.inspect}"
+        end
+      end
 
       def resolve(class_name)
         require "storage_tables/service/#{class_name.to_s.underscore}_service"

--- a/lib/storage_tables/service/configurator.rb
+++ b/lib/storage_tables/service/configurator.rb
@@ -20,7 +20,7 @@ module StorageTables
       def build(service_name)
         config = config_for(service_name.to_sym)
         resolve(config.fetch(:service)).build(
-          **config, configurator: self, name: service_name
+          **config, name: service_name
         )
       end
 

--- a/lib/storage_tables/service/configurator.rb
+++ b/lib/storage_tables/service/configurator.rb
@@ -20,7 +20,7 @@ module StorageTables
       def build(service_name)
         config = config_for(service_name.to_sym)
         resolve(config.fetch(:service)).build(
-          **config, name: service_name
+          **config.except(:service), name: service_name
         )
       end
 
@@ -28,7 +28,8 @@ module StorageTables
 
       def config_for(name)
         configurations.fetch name do
-          raise "Missing configuration for the #{name.inspect} Storage Storage service. Configurations available for #{configurations.keys.inspect}"
+          raise "Missing configuration for the #{name.inspect} Storage Storage service. " \
+                "Configurations available for #{configurations.keys.inspect}"
         end
       end
 

--- a/lib/storage_tables/service/configurator.rb
+++ b/lib/storage_tables/service/configurator.rb
@@ -7,6 +7,21 @@ module StorageTables
   class Service
     # Set the storage service to be used by Storage Tables.
     class Configurator < ActiveStorage::Service::Configurator
+      def self.build(service_name, configurations)
+        new(configurations).build(service_name)
+      end
+
+      def initialize(configurations)
+        @configurations = configurations.deep_symbolize_keys
+      end
+
+      def build(service_name)
+        config = config_for(service_name.to_sym)
+        resolve(config.fetch(:service)).build(
+          **config, configurator: self, name: service_name
+        )
+      end
+
       private
 
       def resolve(class_name)

--- a/lib/storage_tables/service/disk_service.rb
+++ b/lib/storage_tables/service/disk_service.rb
@@ -6,8 +6,8 @@ require "openssl"
 require "active_support/core_ext/numeric/bytes"
 
 module StorageTables
-  # Local disk storage service.
   class Service
+    # Local disk storage service.
     class DiskService < Service
       attr_accessor :root
 
@@ -16,13 +16,6 @@ module StorageTables
         @public = public
 
         super()
-      end
-
-      def upload(checksum, io, **)
-        instrument(:upload, checksum:) do
-          IO.copy_stream(io, make_path_for(checksum))
-          ensure_integrity_of(checksum)
-        end
       end
 
       def download(checksum, &block)

--- a/lib/storage_tables/service/disk_service.rb
+++ b/lib/storage_tables/service/disk_service.rb
@@ -7,82 +7,140 @@ require "active_support/core_ext/numeric/bytes"
 
 module StorageTables
   # Local disk storage service.
-  class Service::DiskService < StorageTables::Service
-    attr_accessor :root
+  class Service
+    class DiskService < Service
+      attr_accessor :root
 
-    def initialize(root:, public: false)
-      @root = root
-      @public = public
+      def initialize(root:, public: false)
+        @root = root
+        @public = public
 
-      super()
-    end
-
-    def path_for(checksum) # :nodoc:
-      File.join root, folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
-    end
-
-    def relative_path_for(checksum)
-      File.join folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
-    end
-
-    def upload(checksum, io, **)
-      # Prevent uploading the same file twice
-      return if exist?(checksum) && file_match?(checksum)
-
-      instrument(:upload, checksum:) do
-        IO.copy_stream(io, make_path_for(checksum))
-        ensure_integrity_of(checksum)
+        super()
       end
-    end
 
-    def url_for_direct_upload(checksum, expires_in:, content_type:, content_length:)
-      instrument(:url, checksum:) do |payload|
-        verified_token_with_expiration = StorageTables.verifier.generate(
-          {
-            checksum:,
-            content_type:,
-            content_length:
-          },
-          expires_in:,
-          purpose: :blob_token
-        )
-
-        url_helpers.update_storage_tables_disk_service_url(verified_token_with_expiration,
-                                                           url_options).tap do |generated_url|
-          payload[:url] = generated_url
+      def upload(checksum, io, **)
+        instrument(:upload, checksum:) do
+          IO.copy_stream(io, make_path_for(checksum))
+          ensure_integrity_of(checksum)
         end
       end
-    end
 
-    private
-
-    def refactored_checksum(checksum)
-      # Replace the forward slash with an underscore
-      # Replace the plus sign with a minus sign
-      checksum.tr("/+", "_-")
-    end
-
-    def folder_for(checksum)
-      "#{checksum[0]}/#{checksum[1..2]}/#{checksum[3..4]}"
-    end
-
-    def ensure_integrity_of(checksum)
-      return if file_match?(checksum)
-
-      delete checksum
-      raise StorageTables::IntegrityError
-    end
-
-    def file_match?(checksum)
-      OpenSSL::Digest.new("SHA3-512").file(path_for(checksum)).base64digest == checksum
-    end
-
-    def url_options
-      if StorageTables::Current.url_options.blank?
-        raise ArgumentError, "Cannot generate URL using Disk service, please set StorageTables::Current.url_options."
+      def download(checksum, &block)
+        if block
+          instrument(:streaming_download, checksum:) do
+            stream key, &block
+          end
+        else
+          instrument(:download, checksum:) do
+            File.binread path_for(checksum)
+          rescue Errno::ENOENT
+            raise StorageTables::FileNotFoundError
+          end
+        end
       end
 
-      StorageTables::Current.url_options
+      def download_chunk(checksum, range)
+        instrument(:download_chunk, checksum:, range:) do
+          File.open(path_for(checksum), "rb") do |file|
+            file.seek range.begin
+            file.read range.size
+          end
+        rescue Errno::ENOENT
+          raise StorageTables::FileNotFoundError
+        end
+      end
+
+      def delete(checksum)
+        instrument(:delete, checksum:) do
+          File.delete path_for(key)
+        rescue Errno::ENOENT
+          # Ignore files already deleted
+        end
+      end
+
+      def exist?(checksum)
+        instrument(:exist, checksum:) do |payload|
+          answer = File.exist? path_for(checksum)
+          payload[:exist] = answer
+          answer
+        end
+      end
+
+      def path_for(checksum) # :nodoc:
+        File.join root, folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
+      end
+
+      def relative_path_for(checksum)
+        File.join folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
+      end
+
+      def upload(checksum, io, **)
+        # Prevent uploading the same file twice
+        return if exist?(checksum) && file_match?(checksum)
+
+        instrument(:upload, checksum:) do
+          IO.copy_stream(io, make_path_for(checksum))
+          ensure_integrity_of(checksum)
+        end
+      end
+
+      def url_for_direct_upload(checksum, expires_in:, content_type:, content_length:)
+        instrument(:url, checksum:) do |payload|
+          verified_token_with_expiration = StorageTables.verifier.generate(
+            {
+              checksum:,
+              content_type:,
+              content_length:
+            },
+            expires_in:,
+            purpose: :blob_token
+          )
+
+          url_helpers.update_storage_tables_disk_service_url(verified_token_with_expiration,
+                                                             url_options).tap do |generated_url|
+            payload[:url] = generated_url
+          end
+        end
+      end
+
+      private
+
+      def refactored_checksum(checksum)
+        # Replace the forward slash with an underscore
+        # Replace the plus sign with a minus sign
+        checksum.tr("/+", "_-")
+      end
+
+      def folder_for(checksum)
+        "#{checksum[0]}/#{checksum[1..2]}/#{checksum[3..4]}"
+      end
+
+      def ensure_integrity_of(checksum)
+        return if file_match?(checksum)
+
+        delete checksum
+        raise StorageTables::IntegrityError
+      end
+
+      def make_path_for(checksum)
+        path_for(checksum).tap { |_path| FileUtils.mkdir_p File.dirname(checksum) }
+      end
+
+      def file_match?(checksum)
+        OpenSSL::Digest.new("SHA3-512").file(path_for(checksum)).base64digest == checksum
+      end
+
+      def url_options
+        if StorageTables::Current.url_options.blank?
+          raise ArgumentError, "Cannot generate URL using Disk service, please set StorageTables::Current.url_options."
+        end
+
+        StorageTables::Current.url_options
+      end
+
+      def url_helpers
+        @url_helpers ||= Rails.application.routes.url_helpers
+      end
     end
   end
 end

--- a/lib/storage_tables/service/disk_service.rb
+++ b/lib/storage_tables/service/disk_service.rb
@@ -133,7 +133,7 @@ module StorageTables
 
       def stream(checksum)
         File.open(path_for(checksum), "rb") do |file|
-          while data = file.read(5.megabytes)
+          while (data = file.read(5.megabytes))
             yield data
           end
         end

--- a/lib/storage_tables/service/disk_service.rb
+++ b/lib/storage_tables/service/disk_service.rb
@@ -1,78 +1,88 @@
 # frozen_string_literal: true
 
-require "active_storage/service/disk_service"
+require "fileutils"
+require "pathname"
+require "openssl"
+require "active_support/core_ext/numeric/bytes"
 
 module StorageTables
-  class Service
-    # Local disk storage service.
-    class DiskService < ActiveStorage::Service::DiskService
-      def path_for(checksum) # :nodoc:
-        File.join root, folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
+  # Local disk storage service.
+  class Service::DiskService < StorageTables::Service
+    attr_accessor :root
+
+    def initialize(root:, public: false)
+      @root = root
+      @public = public
+
+      super()
+    end
+
+    def path_for(checksum) # :nodoc:
+      File.join root, folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
+    end
+
+    def relative_path_for(checksum)
+      File.join folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
+    end
+
+    def upload(checksum, io, **)
+      # Prevent uploading the same file twice
+      return if exist?(checksum) && file_match?(checksum)
+
+      instrument(:upload, checksum:) do
+        IO.copy_stream(io, make_path_for(checksum))
+        ensure_integrity_of(checksum)
       end
+    end
 
-      def relative_path_for(checksum)
-        File.join folder_for(refactored_checksum(checksum)), refactored_checksum(checksum)
-      end
+    def url_for_direct_upload(checksum, expires_in:, content_type:, content_length:)
+      instrument(:url, checksum:) do |payload|
+        verified_token_with_expiration = StorageTables.verifier.generate(
+          {
+            checksum:,
+            content_type:,
+            content_length:
+          },
+          expires_in:,
+          purpose: :blob_token
+        )
 
-      def upload(checksum, io, **)
-        # Prevent uploading the same file twice
-        return if exist?(checksum) && file_match?(checksum)
-
-        instrument(:upload, checksum:) do
-          IO.copy_stream(io, make_path_for(checksum))
-          ensure_integrity_of(checksum)
+        url_helpers.update_storage_tables_disk_service_url(verified_token_with_expiration,
+                                                           url_options).tap do |generated_url|
+          payload[:url] = generated_url
         end
       end
+    end
 
-      def url_for_direct_upload(checksum, expires_in:, content_type:, content_length:)
-        instrument(:url, checksum:) do |payload|
-          verified_token_with_expiration = StorageTables.verifier.generate(
-            {
-              checksum:,
-              content_type:,
-              content_length:
-            },
-            expires_in:,
-            purpose: :blob_token
-          )
+    private
 
-          url_helpers.update_storage_tables_disk_service_url(verified_token_with_expiration,
-                                                             url_options).tap do |generated_url|
-            payload[:url] = generated_url
-          end
-        end
+    def refactored_checksum(checksum)
+      # Replace the forward slash with an underscore
+      # Replace the plus sign with a minus sign
+      checksum.tr("/+", "_-")
+    end
+
+    def folder_for(checksum)
+      "#{checksum[0]}/#{checksum[1..2]}/#{checksum[3..4]}"
+    end
+
+    def ensure_integrity_of(checksum)
+      return if file_match?(checksum)
+
+      delete checksum
+      raise StorageTables::IntegrityError
+    end
+
+    def file_match?(checksum)
+      OpenSSL::Digest.new("SHA3-512").file(path_for(checksum)).base64digest == checksum
+    end
+
+    def url_options
+      if StorageTables::Current.url_options.blank?
+        raise ArgumentError, "Cannot generate URL using Disk service, please set StorageTables::Current.url_options."
       end
 
-      private
-
-      def refactored_checksum(checksum)
-        # Replace the forward slash with an underscore
-        # Replace the plus sign with a minus sign
-        checksum.tr("/+", "_-")
-      end
-
-      def folder_for(checksum)
-        "#{checksum[0]}/#{checksum[1..2]}/#{checksum[3..4]}"
-      end
-
-      def ensure_integrity_of(checksum)
-        return if file_match?(checksum)
-
-        delete checksum
-        raise StorageTables::IntegrityError
-      end
-
-      def file_match?(checksum)
-        OpenSSL::Digest.new("SHA3-512").file(path_for(checksum)).base64digest == checksum
-      end
-
-      def url_options
-        if StorageTables::Current.url_options.blank?
-          raise ArgumentError, "Cannot generate URL using Disk service, please set StorageTables::Current.url_options."
-        end
-
-        StorageTables::Current.url_options
-      end
+      StorageTables::Current.url_options
     end
   end
 end

--- a/lib/storage_tables/service/registry.rb
+++ b/lib/storage_tables/service/registry.rb
@@ -6,8 +6,28 @@ require "storage_tables/service/configurator"
 
 module StorageTables
   class Service
-    class Registry < ActiveStorage::Service::Registry # :nodoc:
+    class Registry # :nodoc:
+      def initialize(configurations)
+        @configurations = configurations.deep_symbolize_keys
+        @services = {}
+      end
+
+      def fetch(name)
+        services.fetch(name.to_sym) do |key|
+          if configurations.include?(key)
+            services[key] = configurator.build(key)
+          elsif block_given?
+            yield key
+          else
+            raise KeyError, "Missing configuration for the #{key} Storage Tables service. " \
+                            "Configurations available for the #{configurations.keys.to_sentence} services."
+          end
+        end
+      end
+
       private
+
+      attr_reader :configurations, :services
 
       def configurator
         @configurator ||= StorageTables::Service::Configurator.new(configurations)

--- a/lib/storage_tables/service/registry.rb
+++ b/lib/storage_tables/service/registry.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "storage_tables/service"
-require "active_storage/service/registry"
 require "storage_tables/service/configurator"
 
 module StorageTables

--- a/lib/storage_tables/service/registry.rb
+++ b/lib/storage_tables/service/registry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "active_storage/service"
+require "storage_tables/service"
 require "active_storage/service/registry"
 require "storage_tables/service/configurator"
 

--- a/test/service/shared_service_tests.rb
+++ b/test/service/shared_service_tests.rb
@@ -77,7 +77,7 @@ module StorageTables
 
         test "existing" do
           assert @service.exist?(@checksum)
-          assert_not @service.exist?(@checksum + "nonsense")
+          assert_not @service.exist?("#{@checksum}nonsense")
         end
 
         test "deleting" do

--- a/test/service/shared_service_tests.rb
+++ b/test/service/shared_service_tests.rb
@@ -12,12 +12,14 @@ module StorageTables
 
       included do
         setup do
+          @checksum = OpenSSL::Digest.new("SHA3-512").base64digest(FIXTURE_DATA)
           @service = self.class.const_get(:SERVICE)
+          @service.upload @checksum, StringIO.new(FIXTURE_DATA)
         end
 
         test "uploading without integrity" do
           data = "Something else entirely!"
-          checksum = OpenSSL::Digest.new("SHA3-512").base64digest(FIXTURE_DATA)
+          checksum = OpenSSL::Digest.new("SHA3-512").base64digest("FIXTURE_DATA")
 
           assert_raises(StorageTables::IntegrityError) do
             @service.upload(checksum, StringIO.new(data))
@@ -26,6 +28,68 @@ module StorageTables
           assert_not @service.exist?(checksum)
         ensure
           @service.delete checksum
+        end
+
+        test "downloading" do
+          assert_equal FIXTURE_DATA, @service.download(@checksum)
+        end
+
+        test "downloading a nonexistent file" do
+          assert_raises(StorageTables::FileNotFoundError) do
+            @service.download(SecureRandom.base58(24))
+          end
+        end
+
+        test "downloading in chunks" do
+          expected_chunks = ["a" * 5.megabytes, "b"]
+          actual_chunks = []
+          io = StringIO.new(expected_chunks.join)
+          checksum = OpenSSL::Digest.new("SHA3-512").base64digest(expected_chunks.join)
+
+          begin
+            @service.upload checksum, io
+
+            @service.download checksum do |chunk|
+              actual_chunks << chunk
+            end
+
+            assert_equal expected_chunks, actual_chunks, "Downloaded chunks did not match uploaded data"
+          ensure
+            @service.delete checksum
+          end
+        end
+
+        test "downloading a nonexistent file in chunks" do
+          assert_raises(StorageTables::FileNotFoundError) do
+            @service.download(SecureRandom.base58(24)) {} # rubocop:disable Lint/EmptyBlock
+          end
+        end
+
+        test "downloading partially" do
+          assert_equal "aaa", @service.download_chunk(@checksum, 19..21)
+        end
+
+        test "partially downloading a nonexistent file" do
+          assert_raises(StorageTables::FileNotFoundError) do
+            @service.download_chunk(SecureRandom.base58(24), 19..21)
+          end
+        end
+
+        test "existing" do
+          assert @service.exist?(@checksum)
+          assert_not @service.exist?(@checksum + "nonsense")
+        end
+
+        test "deleting" do
+          @service.delete @checksum
+
+          assert_not @service.exist?(@checksum)
+        end
+
+        test "deleting nonexistent key" do
+          assert_nothing_raised do
+            @service.delete SecureRandom.base58(24)
+          end
         end
       end
     end


### PR DESCRIPTION
To reduce dependency on `ActiveStorage`, the disk_service will no longer be a subclass of the `ActiveStorage::DiskService`