### PR TITLE
Refactor base controller and disk controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 Gemfile.lock
 .ruby-version
 .vscode/
+.env

--- a/app/controllers/storage_tables/base_controller.rb
+++ b/app/controllers/storage_tables/base_controller.rb
@@ -10,3 +10,4 @@ module StorageTables
     self.etag_with_template_digest = false
   end
 end
+        

--- a/app/controllers/storage_tables/base_controller.rb
+++ b/app/controllers/storage_tables/base_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# The base class for all Active Storage controllers.
+module StorageTables
+  class BaseController < ActionController::Base # rubocop:disable Rails/ApplicationController
+    include StorageTables::SetCurrent
+
+    protect_from_forgery with: :exception
+
+    self.etag_with_template_digest = false
+  end
+end

--- a/app/controllers/storage_tables/base_controller.rb
+++ b/app/controllers/storage_tables/base_controller.rb
@@ -10,4 +10,3 @@ module StorageTables
     self.etag_with_template_digest = false
   end
 end
-        

--- a/app/controllers/storage_tables/base_controller.rb
+++ b/app/controllers/storage_tables/base_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# The base class for all Active Storage controllers.
 module StorageTables
+  # The base class for all StorageTables controllers.
   class BaseController < ActionController::Base # rubocop:disable Rails/ApplicationController
     include StorageTables::SetCurrent
 

--- a/app/controllers/storage_tables/disk_controller.rb
+++ b/app/controllers/storage_tables/disk_controller.rb
@@ -6,6 +6,8 @@ module StorageTables
   # Always go through the BlobsController, or your own authenticated controller, rather than directly
   # to the service URL.
   class DiskController < BaseController
+    protect_from_forgery except: :update
+
     def update
       return head :not_found unless token
 

--- a/app/controllers/storage_tables/disk_controller.rb
+++ b/app/controllers/storage_tables/disk_controller.rb
@@ -5,9 +5,7 @@ module StorageTables
   # This means using expiring, signed URLs that are meant for immediate access, not permanent linking.
   # Always go through the BlobsController, or your own authenticated controller, rather than directly
   # to the service URL.
-  class DiskController < ActiveStorage::BaseController
-    include StorageTables::SetCurrent
-
+  class DiskController < BaseController
     def update
       return head :not_found unless token
 

--- a/app/controllers/storage_tables/disk_controller.rb
+++ b/app/controllers/storage_tables/disk_controller.rb
@@ -6,8 +6,6 @@ module StorageTables
   # Always go through the BlobsController, or your own authenticated controller, rather than directly
   # to the service URL.
   class DiskController < BaseController
-    include ActiveStorage::FileServer
-
     skip_forgery_protection
 
     def update

--- a/app/controllers/storage_tables/disk_controller.rb
+++ b/app/controllers/storage_tables/disk_controller.rb
@@ -6,7 +6,9 @@ module StorageTables
   # Always go through the BlobsController, or your own authenticated controller, rather than directly
   # to the service URL.
   class DiskController < BaseController
-    protect_from_forgery except: :update
+    include ActiveStorage::FileServer
+
+    skip_forgery_protection
 
     def update
       return head :not_found unless token


### PR DESCRIPTION
This commit refactors the base controller and disk controller in the StorageTables module. The base controller is now a subclass of ActionController::Base and includes the StorageTables::SetCurrent module. It also sets protect_from_forgery with :exception and disables etag_with_template_digest. The disk controller now inherits from the base controller instead of ActiveStorage::BaseController. This change improves code organization and maintainability.