### PR TITLE
StorageTables::Filename class for filename handling instead of ActiveStorage::Filename

### DIFF
--- a/app/models/storage_tables/attachment.rb
+++ b/app/models/storage_tables/attachment.rb
@@ -29,11 +29,11 @@ module StorageTables
       "#{blob_key}#{checksum}=="
     end
 
-    # Returns an ActiveStorage::Filename instance of the filename that can be
+    # Returns an StorageTables::Filename instance of the filename that can be
     # queried for basename, extension, and a sanitized version of the filename
     # that's safe to use in URLs.
     def filename
-      ActiveStorage::Filename.new(self[:filename])
+      StorageTables::Filename.new(self[:filename])
     end
   end
 end

--- a/app/models/storage_tables/filename.rb
+++ b/app/models/storage_tables/filename.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module StorageTables
+    # = StorageTables \Filename
+    #
+    # Encapsulates a string representing a filename to provide convenient access to parts of it and sanitization.
+    # A Filename instance is returned by StorageTables::Blob#filename, and is comparable so it can be used for sorting.
+  class Filename
+    include Comparable
+
+    class << self
+      # Returns a Filename instance based on the given filename. If the filename is a Filename, it is
+      # returned unmodified. If it is a String, it is passed to StorageTables::Filename.new.
+      def wrap(filename)
+        filename.is_a?(self) ? filename : new(filename)
+      end
+    end
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    # Returns the part of the filename preceding any extension.
+    #
+    #   StorageTables::Filename.new("racecar.jpg").base # => "racecar"
+    #   StorageTables::Filename.new("racecar").base     # => "racecar"
+    #   StorageTables::Filename.new(".gitignore").base  # => ".gitignore"
+    def base
+      File.basename @filename, extension_with_delimiter
+    end
+
+    # Returns the extension of the filename (i.e. the substring following the last dot, excluding a dot at the
+    # beginning) with the dot that precedes it. If the filename has no extension, an empty string is returned.
+    #
+    #   StorageTables::Filename.new("racecar.jpg").extension_with_delimiter # => ".jpg"
+    #   StorageTables::Filename.new("racecar").extension_with_delimiter     # => ""
+    #   StorageTables::Filename.new(".gitignore").extension_with_delimiter  # => ""
+    def extension_with_delimiter
+      File.extname @filename
+    end
+
+    # Returns the extension of the filename (i.e. the substring following the last dot, excluding a dot at
+    # the beginning). If the filename has no extension, an empty string is returned.
+    #
+    #   StorageTables::Filename.new("racecar.jpg").extension_without_delimiter # => "jpg"
+    #   StorageTables::Filename.new("racecar").extension_without_delimiter     # => ""
+    #   StorageTables::Filename.new(".gitignore").extension_without_delimiter  # => ""
+    def extension_without_delimiter
+      extension_with_delimiter.from(1).to_s
+    end
+
+    alias extension extension_without_delimiter
+
+    # Returns the sanitized filename.
+    #
+    #   StorageTables::Filename.new("foo:bar.jpg").sanitized # => "foo-bar.jpg"
+    #   StorageTables::Filename.new("foo/bar.jpg").sanitized # => "foo-bar.jpg"
+    #
+    # Characters considered unsafe for storage (e.g. \, $, and the RTL override character) are replaced with a dash.
+    def sanitized
+      @filename.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr(
+        "\u{202E}%$|:;/<>?*\"\t\r\n\\", "-"
+      )
+    end
+
+    # Returns the sanitized version of the filename.
+    delegate :to_s, to: :sanitized
+
+    def as_json(*)
+      to_s
+    end
+
+    def <=>(other)
+      to_s.downcase <=> other.to_s.downcase
+    end
+  end
+end

--- a/app/models/storage_tables/filename.rb
+++ b/app/models/storage_tables/filename.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module StorageTables
-    # = StorageTables \Filename
-    #
-    # Encapsulates a string representing a filename to provide convenient access to parts of it and sanitization.
-    # A Filename instance is returned by StorageTables::Blob#filename, and is comparable so it can be used for sorting.
+  # = StorageTables \Filename
+  #
+  # Encapsulates a string representing a filename to provide convenient access to parts of it and sanitization.
+  # A Filename instance is returned by StorageTables::Blob#filename, and is comparable so it can be used for sorting.
   class Filename
     include Comparable
 

--- a/test/models/filename_test.rb
+++ b/test/models/filename_test.rb
@@ -60,5 +60,10 @@ module StorageTables
       assert_equal '{"filename":"foo.pdf"}', { filename: StorageTables::Filename.new("foo.pdf") }.to_json
       assert_equal '{"filename":"foo.pdf"}', JSON.generate(filename: StorageTables::Filename.new("foo.pdf"))
     end
+
+    test "#wrap" do
+        assert_equal StorageTables::Filename.new("foo.pdf"), StorageTables::Filename.wrap(StorageTables::Filename.new("foo.pdf"))
+        assert_equal StorageTables::Filename.new("foo.pdf"), StorageTables::Filename.wrap("foo.pdf")
+    end
   end
 end

--- a/test/models/filename_test.rb
+++ b/test/models/filename_test.rb
@@ -62,8 +62,9 @@ module StorageTables
     end
 
     test "#wrap" do
-        assert_equal StorageTables::Filename.new("foo.pdf"), StorageTables::Filename.wrap(StorageTables::Filename.new("foo.pdf"))
-        assert_equal StorageTables::Filename.new("foo.pdf"), StorageTables::Filename.wrap("foo.pdf")
+      assert_equal StorageTables::Filename.new("foo.pdf"),
+                   StorageTables::Filename.wrap(StorageTables::Filename.new("foo.pdf"))
+      assert_equal StorageTables::Filename.new("foo.pdf"), StorageTables::Filename.wrap("foo.pdf")
     end
   end
 end

--- a/test/models/filename_test.rb
+++ b/test/models/filename_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module StorageTables
+  class FilenameTest < ActiveSupport::TestCase
+    test "base" do
+      assert_equal "racecar", StorageTables::Filename.new("racecar.jpg").base
+      assert_equal "race.car", StorageTables::Filename.new("race.car.jpg").base
+      assert_equal "racecar", StorageTables::Filename.new("racecar").base
+    end
+
+    test "extension with delimiter" do
+      assert_equal ".jpg", StorageTables::Filename.new("racecar.jpg").extension_with_delimiter
+      assert_equal ".jpg", StorageTables::Filename.new("race.car.jpg").extension_with_delimiter
+      assert_equal "", StorageTables::Filename.new("racecar").extension_with_delimiter
+    end
+
+    test "extension without delimiter" do
+      assert_equal "jpg", StorageTables::Filename.new("racecar.jpg").extension_without_delimiter
+      assert_equal "jpg", StorageTables::Filename.new("race.car.jpg").extension_without_delimiter
+      assert_equal "", StorageTables::Filename.new("racecar").extension_without_delimiter
+    end
+
+    test "sanitize" do
+      "%$|:;/<>?*\"\t\r\n\\".each_char do |character|
+        filename = StorageTables::Filename.new("foo#{character}bar.pdf")
+
+        assert_equal "foo-bar.pdf", filename.sanitized
+        assert_equal "foo-bar.pdf", filename.to_s
+      end
+    end
+
+    test "sanitize transcodes to valid UTF-8" do
+      { (+"\xF6").force_encoding(Encoding::ISO8859_1) => "ö",
+        (+"\xC3").force_encoding(Encoding::ISO8859_1) => "Ã",
+        "\xAD" => "�",
+        "\xCF" => "�",
+        "\x00" => "" }.each do |actual, expected|
+        assert_equal expected, StorageTables::Filename.new(actual).sanitized
+      end
+    end
+
+    test "strips RTL override chars used to spoof unsafe executables as docs" do
+      # Would be displayed in Windows as "evilexe.pdf" due to the right-to-left
+      # (RTL) override char!
+      assert_equal "evil-fdp.exe", StorageTables::Filename.new("evil\u{202E}fdp.exe").sanitized
+    end
+
+    test "compare case-insensitively" do
+      assert_equal StorageTables::Filename.new("foobar.pdf"), StorageTables::Filename.new("FooBar.PDF")
+    end
+
+    test "compare sanitized" do
+      assert_equal StorageTables::Filename.new("foo-bar.pdf"), StorageTables::Filename.new("foo\tbar.pdf")
+    end
+
+    test "encoding to json" do
+      assert_equal '"foo.pdf"', StorageTables::Filename.new("foo.pdf").to_json
+      assert_equal '{"filename":"foo.pdf"}', { filename: StorageTables::Filename.new("foo.pdf") }.to_json
+      assert_equal '{"filename":"foo.pdf"}', JSON.generate(filename: StorageTables::Filename.new("foo.pdf"))
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces the `StorageTables::Filename` class to encapsulate filename handling and sanitization, replacing the previous use of `ActiveStorage::Filename`. The changes include updates to the `filename` method in `attachment.rb`, the addition of the new `filename.rb` file, and corresponding tests.

### Introduction of `StorageTables::Filename`:

* [`app/models/storage_tables/attachment.rb`](diffhunk://#diff-85dc030e0383a6b569f7214d3a26ecf243c2f4050e35a3b786d33fc429b34514L32-R36): Updated the `filename` method to use `StorageTables::Filename` instead of `ActiveStorage::Filename`.
* [`app/models/storage_tables/filename.rb`](diffhunk://#diff-5184bd0ac482763d39908a8ff6301038a1840afe2c62f7bfb5c637948411779aR1-R77): Added the `StorageTables::Filename` class to encapsulate filename handling, including methods for getting the base name, extension, and sanitized version of a filename.

### Tests for `StorageTables::Filename`:

* [`test/models/filename_test.rb`](diffhunk://#diff-7ee9cc52af23f58eda6729b29f43bfa9a13a2ef93b7004298b6601329701c8f5R1-R64): Added unit tests for the `StorageTables::Filename` class to verify its functionality, including tests for base name extraction, extension handling, sanitization, and JSON encoding.