### PR TITLE
Add configuration for active_support.to_time_preserves_timezone in preparation for Rails 8.1

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -22,5 +22,9 @@ module Dummy
     config.active_storage.service = :local
 
     config.storage_tables.service = :local
+
+    # DEPRECATION WARNING: `to_time` will always preserve the full timezone rather than offset of the receiver 
+    # in Rails 8.1. To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`.
+    config.active_support.to_time_preserves_timezone = :zone
   end
 end


### PR DESCRIPTION
This pull request includes a small change to the `test/dummy/config/application.rb` file. The change addresses a deprecation warning by setting a configuration option to preserve the full timezone rather than the offset in Rails 8.1.

* [`test/dummy/config/application.rb`](diffhunk://#diff-205386a3cd43d6fbf2785ab0acf2293d8f79622baf8b3230e98146135bf49f1bR25-R28): Added `config.active_support.to_time_preserves_timezone = :zone` to handle the deprecation warning about `to_time` preserving the full timezone in Rails 8.1.