### PR TITLE
Implement StorageTables::Downloader for file downloading

### DIFF
--- a/lib/storage_tables/downloader.rb
+++ b/lib/storage_tables/downloader.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module StorageTables
+  class Downloader # :nodoc:
+    attr_reader :service
+
+    def initialize(service)
+      @service = service
+    end
+
+    def open(checksum, verify: true, name: "StorageTables-", tmpdir: nil)
+      open_tempfile(name, tmpdir) do |file|
+        download checksum, file
+        verify_integrity_of(file, checksum:) if verify
+        yield file
+      end
+    end
+
+    private
+
+    def open_tempfile(name, tmpdir = nil)
+      file = Tempfile.open(name, tmpdir)
+
+      begin
+        yield file
+      ensure
+        file.close!
+      end
+    end
+
+    def download(checksum, file)
+      file.binmode
+      service.download(checksum) { |chunk| file.write(chunk) }
+      file.flush
+      file.rewind
+    end
+
+    def verify_integrity_of(file, checksum:)
+      return if OpenSSL::Digest.new("SHA3-512").file(file).base64digest == checksum
+
+      raise StorageTables::IntegrityError
+    end
+  end
+end

--- a/lib/storage_tables/service.rb
+++ b/lib/storage_tables/service.rb
@@ -50,7 +50,7 @@ module StorageTables
     end
 
     def open(...)
-      ActiveStorage::Downloader.new(self).open(...)
+      StorageTables::Downloader.new(self).open(...)
     end
 
     # Concatenate multiple files into a single "composed" file.

--- a/lib/storage_tables/service.rb
+++ b/lib/storage_tables/service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "storage_tables/downloader"
+
 module StorageTables
   # Loads and configures the Storage service to be used to store files.
   class Service


### PR DESCRIPTION
This pull request introduces a new `Downloader` class to the `StorageTables` module, which is responsible for downloading and verifying the integrity of files. Additionally, it updates the `open` method in the `StorageTables::Service` class to use the new `Downloader` class.

New `Downloader` class:

* [`lib/storage_tables/downloader.rb`](diffhunk://#diff-2453abc63b521e3f07a71503c70eab25d1128b80363dc2eb3b85169d5b99e0e6R1-R44): Added a new `Downloader` class to handle downloading files and verifying their integrity. The class includes methods for opening a temporary file, downloading the file, and verifying its checksum using SHA3-512.

Update to `StorageTables::Service`:

* [`lib/storage_tables/service.rb`](diffhunk://#diff-1dab1a3fee7814c84fd0dff3b459ac7ca6b9eb8c6319933cb6d0bd7b1f0da503L53-R53): Modified the `open` method to use the new `StorageTables::Downloader` class instead of `ActiveStorage::Downloader`.