### PR TITLE
Add initializer for storage_tables.queues configuration

### DIFF
--- a/lib/storage_tables/engine.rb
+++ b/lib/storage_tables/engine.rb
@@ -44,6 +44,12 @@ module StorageTables
       end
     end
 
+    initializer "storage_tables.queues" do
+      config.after_initialize do |app|
+        StorageTables.queues = app.config.storage_tables.queues || {}
+      end
+    end
+
     initializer "storage_tables.reflection" do
       ActiveSupport.on_load(:active_record) do
         include Reflection::ActiveRecordExtensions


### PR DESCRIPTION
This pull request introduces a new initializer to the `Engine` class in the `lib/storage_tables/engine.rb` file. The initializer sets up the `StorageTables.queues` configuration after the application has been initialized.

Initialization changes:

* [`lib/storage_tables/engine.rb`](diffhunk://#diff-86f0a7c784873675299a26fe1b37305fb48829f84efe077ced4b6c6475ddba82R47-R52): Added an initializer to set `StorageTables.queues` using the application's configuration for storage tables queues.