### PR TITLE
Add inheritable options for storage_tables.queues configuration

### DIFF
--- a/lib/storage_tables/engine.rb
+++ b/lib/storage_tables/engine.rb
@@ -12,6 +12,7 @@ module StorageTables
     isolate_namespace StorageTables
 
     config.storage_tables = ActiveSupport::OrderedOptions.new
+    config.storage_tables.queues = ActiveSupport::InheritableOptions.new
 
     initializer "storage_tables.attached" do
       require "storage_tables/attached"


### PR DESCRIPTION
This pull request includes a small change to the `lib/storage_tables/engine.rb` file. The change introduces a new configuration option for `storage_tables` by adding `ActiveSupport::InheritableOptions` to handle queues.

* [`lib/storage_tables/engine.rb`](diffhunk://#diff-86f0a7c784873675299a26fe1b37305fb48829f84efe077ced4b6c6475ddba82R15): Added `config.storage_tables.queues` to use `ActiveSupport::InheritableOptions`.