### PR TITLE
Fix type of payload in mirror instrumentation

### DIFF
--- a/lib/storage_tables/service/mirror_service.rb
+++ b/lib/storage_tables/service/mirror_service.rb
@@ -61,7 +61,7 @@ module StorageTables
 
       # Copy the file at the +checksum+ from the primary service to each of the mirrors where it doesn't already exist.
       def mirror(checksum)
-        instrument(:mirror, checksum) do
+        instrument(:mirror, checksum:) do
           if (mirrors_in_need_of_mirroring = mirrors.reject { |service| service.exist?(checksum) }).any?
             primary.open(checksum) do |io|
               mirrors_in_need_of_mirroring.each do |service|

--- a/lib/storage_tables/service/s3_service.rb
+++ b/lib/storage_tables/service/s3_service.rb
@@ -11,6 +11,8 @@ module StorageTables
     # See StorageTables::Service for the generic API documentation that applies to all services.
     class S3Service < Service
       MULTIPART_THRESHOLD = 100.megabytes
+      MAXIMUM_UPLOAD_PARTS_COUNT = 10_000
+      MINIMUM_UPLOAD_PART_SIZE   = 5.megabytes
 
       attr_reader :client, :bucket, :multipart_upload_threshold, :upload_options
 
@@ -108,9 +110,6 @@ module StorageTables
                                                    type: disposition, filename:
                                                  ), response_content_type: content_type, **client_opts
       end
-
-      MAXIMUM_UPLOAD_PARTS_COUNT = 10_000
-      MINIMUM_UPLOAD_PART_SIZE   = 5.megabytes
 
       def upload_with_single_part(checksum, io, content_type: nil, content_disposition: nil,
                                   custom_metadata: {})

--- a/test/service/mirror_service_test.rb
+++ b/test/service/mirror_service_test.rb
@@ -92,8 +92,7 @@ module StorageTables
       end
 
       test "when file doesn't exist on primary when mirroring" do
-        data     = "Something else entirely!"
-        checksum = generate_checksum(data)
+        checksum = generate_checksum(name)
 
         assert_raises StorageTables::FileNotFoundError do
           @service.mirror(checksum)

--- a/test/service/mirror_service_test.rb
+++ b/test/service/mirror_service_test.rb
@@ -91,6 +91,15 @@ module StorageTables
         assert_equal data, @service.mirrors.third.download(checksum)
       end
 
+      test "when file doesn't exist on primary when mirroring" do
+        data     = "Something else entirely!"
+        checksum = generate_checksum(data)
+
+        assert_raises StorageTables::FileNotFoundError do
+          @service.mirror(checksum)
+        end
+      end
+
       test "path for file in primary service" do
         assert_equal @service.primary.path_for(@checksum), @service.path_for(@checksum)
       end


### PR DESCRIPTION
Fix bug in instrumentation payload. As this is given a string as expecting a hash.

- Added spec for raise while mirroring and file not found