### PR TITLE
Add checksum-based querying methods to Attachment models

### DIFF
--- a/app/models/storage_tables/attachment.rb
+++ b/app/models/storage_tables/attachment.rb
@@ -35,5 +35,30 @@ module StorageTables
     def filename
       StorageTables::Filename.new(self[:filename])
     end
+
+    class << self
+      def find_by_checksum(checksum)
+        find_by(blob_key: checksum[0], checksum: checksum[1..].chomp("=="))
+      end
+
+      def find_by_checksum!(checksum)
+        find_by!(blob_key: checksum[0], checksum: checksum[1..].chomp("=="))
+      end
+
+      def where_checksum(input)
+        if input.is_a?(Array)
+          where([:blob_key, :checksum] => input.map { checksum_to_primary(_1) })
+        else
+          where(blob_key: input[0], checksum: input[1..].chomp("=="))
+        end
+      end
+
+      private
+
+      # Cut the checksum into an Array to match the primary key
+      def checksum_to_primary(checksum)
+        [checksum[1..].chomp("=="), checksum[0]]
+      end
+    end
   end
 end

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -188,6 +188,57 @@ module StorageTables
       assert_equal "blob is nil", error.message
     end
 
+    ## StorageTables::Blob.where_checksum
+
+    test "where_checksum" do
+      blob = create_blob(data: "First blob")
+      blob2 = create_blob(data: "Second blob")
+      attachment = UserPhotoAttachment.create!(record: @user, blob: blob, filename: "test.txt")
+      attachment2 = UserPhotoAttachment.create!(record: @user, blob: blob2, filename: "test.txt")
+
+      checksum = blob.checksum
+
+      search = UserPhotoAttachment.where_checksum(checksum)
+
+      assert_includes search, attachment
+      assert_not_includes search, attachment2
+    end
+
+    test "where_checksum with array" do
+      blob = create_blob(data: "First blob")
+      blob2 = create_blob(data: "Second blob")
+      blob3 = create_blob(data: "Third blob")
+      attachment = UserPhotoAttachment.create!(record: @user, blob: blob, filename: "test.txt")
+      attachment2 = UserPhotoAttachment.create!(record: @user, blob: blob2, filename: "test.txt")
+      attachment3 = UserPhotoAttachment.create!(record: @user, blob: blob3, filename: "test.txt")
+
+      checksum = blob.checksum
+      checksum2 = blob2.checksum
+
+      search = UserPhotoAttachment.where_checksum([checksum, checksum2])
+
+      assert_includes search, attachment
+      assert_includes search, attachment2
+      assert_not_includes search, attachment3
+    end
+
+    ## StorageTables::Blob.find_by_checksum!
+
+    test "find_by_checksum!" do
+      blob = create_blob(data: "First blob")
+      attachment = UserAvatarAttachment.create!(record: @user, blob: blob, filename: "test.txt")
+
+      search = UserAvatarAttachment.find_by_checksum!(blob.checksum)
+
+      assert_equal attachment, search
+    end
+
+    test "find_by_checksum! with non-existing checksum" do
+      assert_raises(ActiveRecord::RecordNotFound) do
+        UserAvatarAttachment.find_by_checksum!("non-existing-checksum")
+      end
+    end
+
     private
 
     def assert_blob_identified_before_owner_validated(owner, blob, content_type)

--- a/test/models/attachment_test.rb
+++ b/test/models/attachment_test.rb
@@ -188,7 +188,7 @@ module StorageTables
       assert_equal "blob is nil", error.message
     end
 
-    ## StorageTables::Blob.where_checksum
+    ## StorageTables::Attachment.where_checksum
 
     test "where_checksum" do
       blob = create_blob(data: "First blob")
@@ -222,7 +222,7 @@ module StorageTables
       assert_not_includes search, attachment3
     end
 
-    ## StorageTables::Blob.find_by_checksum!
+    ## StorageTables::Attachment.find_by_checksum!
 
     test "find_by_checksum!" do
       blob = create_blob(data: "First blob")


### PR DESCRIPTION
This pull request introduces several new methods for handling checksums in the `Attachment` model and adds corresponding tests to ensure their functionality. The changes are primarily focused on enabling more efficient querying of attachments based on their checksums.

### Enhancements to checksum handling:

* [`app/models/storage_tables/attachment.rb`](diffhunk://#diff-85dc030e0383a6b569f7214d3a26ecf243c2f4050e35a3b786d33fc429b34514R38-R62): Added new class methods `find_by_checksum`, `find_by_checksum!`, and `where_checksum` to facilitate querying attachments by their checksums. These methods include logic to handle both single checksum strings and arrays of checksums.

### Tests for new checksum methods:

* [`test/models/attachment_test.rb`](diffhunk://#diff-3690876f903a45f2ea0849d648aaf10050303bdfedb5e458765c97dbfbee3553R191-R241): Added tests for the new `where_checksum`, `find_by_checksum!`, and their respective edge cases to ensure they work correctly and handle non-existing checksums appropriately.