### PR TITLE
Service with backup

### DIFF
--- a/app/jobs/storage_tables/backfill_job.rb
+++ b/app/jobs/storage_tables/backfill_job.rb
@@ -5,8 +5,8 @@ module StorageTables
   class BackfillJob < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
     queue_as { StorageTables.queues[:backfill] }
 
-    discard_on StorageTables::FileNotFoundError
-    retry_on StorageTables::IntegrityError, attempts: 10, wait: :polynomially_longer
+    retry_on StorageTables::FileNotFoundError, attempts: 5, wait: :polynomially_longer
+    retry_on StorageTables::IntegrityError, attempts: 5, wait: :polynomially_longer
 
     def perform(checksum)
       StorageTables::Blob.service.try(:backfill, checksum)

--- a/app/jobs/storage_tables/backfill_job.rb
+++ b/app/jobs/storage_tables/backfill_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module StorageTables
+  # Provides asynchronous backfilling of missing files from the backup service to the primary service.
+  class BackfillJob < ActiveJob::Base # rubocop:disable Rails/ApplicationJob
+    queue_as { StorageTables.queues[:backfill] }
+
+    discard_on StorageTables::FileNotFoundError
+    retry_on StorageTables::IntegrityError, attempts: 10, wait: :polynomially_longer
+
+    def perform(checksum)
+      StorageTables::Blob.service.try(:backfill, checksum)
+    end
+  end
+end

--- a/lib/storage_tables/service/backup_service.rb
+++ b/lib/storage_tables/service/backup_service.rb
@@ -46,9 +46,9 @@ module StorageTables
 
       def backfill(checksum)
         instrument(:backfill_from_backup, checksum:) do
-          primary.open(checksum) do |io|
+          backup.open(checksum) do |io|
             io.rewind
-            backup.upload checksum, io
+            primary.upload checksum, io
           end
         end
       end

--- a/lib/storage_tables/service/backup_service.rb
+++ b/lib/storage_tables/service/backup_service.rb
@@ -20,6 +20,14 @@ module StorageTables
         backfill_later(checksum)
       end
 
+      def download_chunk(checksum, range)
+        primary.download_chunk(checksum, range)
+      rescue StorageTables::FileNotFoundError
+        backup.download_chunk(checksum, range)
+
+        backfill_later(checksum)
+      end
+
       def exist?(checksum)
         primary.exist?(checksum) || backup.exist?(checksum)
       end

--- a/lib/storage_tables/service/backup_service.rb
+++ b/lib/storage_tables/service/backup_service.rb
@@ -15,17 +15,21 @@ module StorageTables
       def download(checksum)
         primary.download(checksum)
       rescue StorageTables::FileNotFoundError
-        backup.download(checksum)
+        data = backup.download(checksum)
 
         backfill_later(checksum)
+
+        data
       end
 
       def download_chunk(checksum, range)
         primary.download_chunk(checksum, range)
       rescue StorageTables::FileNotFoundError
-        backup.download_chunk(checksum, range)
+        data = backup.download_chunk(checksum, range)
 
         backfill_later(checksum)
+
+        data
       end
 
       def exist?(checksum)

--- a/lib/storage_tables/service/backup_service.rb
+++ b/lib/storage_tables/service/backup_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/module/delegation"
+
+module StorageTables
+  class Service
+    # A service that has a primary and a backup, this will fallback to the backup
+    # if the primary is missing a file.
+    class BackupService < Service
+      attr_reader :primary, :backup
+
+      delegate :delete, :url, :path_for, :upload, :url_for_direct_upload,
+               :headers_for_direct_upload, :compose, to: :primary
+
+      def download(checksum)
+        primary.download(checksum)
+      rescue StorageTables::FileNotFoundError
+        backup.download(checksum)
+
+        backfill_later(checksum)
+      end
+
+      def exist?(checksum)
+        primary.exist?(checksum) || backup.exist?(checksum)
+      end
+
+      def backfill_later(checksum)
+        StorageTables::BackfillJob.perform_later checksum
+      end
+
+      def backfill(checksum)
+        instrument(:backfill_from_backup, checksum:) do
+          primary.open(checksum) do |io|
+            io.rewind
+            backup.upload checksum, io
+          end
+        end
+      end
+
+      # Stitch together from named services.
+      def self.build(primary:, backup:, name:, configurator:, **) # :nodoc:
+        new(
+          primary: configurator.build(primary),
+          backup: configurator.build(backup)
+        ).tap do |service_instance|
+          service_instance.name = name
+        end
+      end
+
+      def initialize(primary:, backup:) # rubocop:disable Lint/MissingSuper
+        @primary = primary
+        @backup = backup
+      end
+    end
+  end
+end

--- a/lib/storage_tables/service/backup_service.rb
+++ b/lib/storage_tables/service/backup_service.rb
@@ -37,7 +37,14 @@ module StorageTables
       end
 
       def exist?(checksum)
-        primary.exist?(checksum) || backup.exist?(checksum)
+        if primary.exist?(checksum)
+          true
+        elsif backup.exist?(checksum)
+          backfill_later(checksum)
+          true
+        else
+          false
+        end
       end
 
       def backfill_later(checksum)

--- a/test/jobs/storage_tables/backfill_job_test.rb
+++ b/test/jobs/storage_tables/backfill_job_test.rb
@@ -8,6 +8,14 @@ module StorageTables
       @checksum = "a" * 64
     end
 
+    test "performs backfill with the given checksum" do
+      StorageTables::Blob.service.stub(:backfill, true) do
+        perform_enqueued_jobs do
+          BackfillJob.perform_later(@checksum)
+        end
+      end
+    end
+
     test "discards job when file is not found" do
       assert_raises(StorageTables::FileNotFoundError) do
         StorageTables::Blob.service.stub(:backfill, raise(StorageTables::FileNotFoundError)) do

--- a/test/jobs/storage_tables/backfill_job_test.rb
+++ b/test/jobs/storage_tables/backfill_job_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module StorageTables
+  class BackfillJobTest < ActiveJob::TestCase
+    setup do
+      @checksum = "a" * 64
+    end
+
+    test "discards job when file is not found" do
+      assert_raises(StorageTables::FileNotFoundError) do
+        StorageTables::Blob.service.stub(:backfill, raise(StorageTables::FileNotFoundError)) do
+          perform_enqueued_jobs do
+            assert_no_enqueued_jobs do
+              BackfillJob.perform_later(@checksum)
+
+              assert_enqueued_with(job: BackfillJob, args: [@checksum])
+            end
+          end
+        end
+      end
+    end
+
+    test "retries on integrity error" do
+      assert_raises(StorageTables::IntegrityError) do
+        StorageTables::Blob.service.stub(:backfill, raise(StorageTables::IntegrityError)) do
+          perform_enqueued_jobs do
+            BackfillJob.perform_later(@checksum)
+
+            assert_enqueued_with(job: BackfillJob, args: [@checksum])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/jobs/storage_tables/backfill_job_test.rb
+++ b/test/jobs/storage_tables/backfill_job_test.rb
@@ -16,14 +16,13 @@ module StorageTables
     setup do
       @checksum = generate_checksum(FIXTURE_DATA)
       @service = self.class.const_get(:SERVICE)
+      StorageTables::Blob.service = @service
     end
 
     test "performs backfill with the given checksum" do
       @service.backup.upload(@checksum, StringIO.new(FIXTURE_DATA))
 
-      perform_enqueued_jobs do
-        BackfillJob.perform_later(@checksum)
-      end
+      BackfillJob.perform_now(@checksum)
 
       assert @service.primary.exist?(@checksum)
     end

--- a/test/service/backup_service_test.rb
+++ b/test/service/backup_service_test.rb
@@ -84,6 +84,16 @@ module StorageTables
           @service.download_chunk(checksum, 0..10)
         end
       end
+
+      test "#backfill copies file from backup to primary" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+        @service.backup.upload(checksum, StringIO.new(data))
+
+        @service.backfill(checksum)
+
+        assert @service.primary.exist?(checksum), "File should exist in primary after backfill"
+      end
     end
   end
 end

--- a/test/service/backup_service_test.rb
+++ b/test/service/backup_service_test.rb
@@ -94,6 +94,24 @@ module StorageTables
 
         assert @service.primary.exist?(checksum), "File should exist in primary after backfill"
       end
+
+      test "#exist? enqueues backfill job when file is only in backup" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+        @service.backup.upload(checksum, StringIO.new(data))
+
+        assert_enqueued_with(job: StorageTables::BackfillJob) do
+          assert @service.exist?(checksum)
+        end
+      end
+
+      test "#exist? returns true when file is in primary" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+        @service.primary.upload(checksum, StringIO.new(data))
+
+        assert @service.exist?(checksum), "File should exist in primary"
+      end
     end
   end
 end

--- a/test/service/backup_service_test.rb
+++ b/test/service/backup_service_test.rb
@@ -45,9 +45,6 @@ module StorageTables
 
         # Should download from backup and trigger backfill
         assert_equal data, @service.download(checksum)
-
-        # Verify backfill happened
-        assert @service.primary.exist?(checksum), "Primary should have the file after backfill"
       end
 
       test "exist? checks both primary and backup services" do

--- a/test/service/backup_service_test.rb
+++ b/test/service/backup_service_test.rb
@@ -74,6 +74,16 @@ module StorageTables
           @service.download(checksum)
         end
       end
+
+      test "backfill job is enqueued when downloading from backup chunk" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+        @service.backup.upload(checksum, StringIO.new(data))
+
+        assert_enqueued_with(job: StorageTables::BackfillJob) do
+          @service.download_chunk(checksum, 0..10)
+        end
+      end
     end
   end
 end

--- a/test/service/backup_service_test.rb
+++ b/test/service/backup_service_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "service/shared_service_tests"
+
+module StorageTables
+  class Service
+    class BackupServiceTest < ActiveSupport::TestCase
+      backup_config = {
+        primary: { service: "Disk", root: Dir.mktmpdir("active_storage_tests_primary") },
+        backup: { service: "Backup", primary: "primary", backup: "original" },
+        original: { service: "Disk", root: Dir.mktmpdir("active_storage_tests_original") }
+      }
+
+      SERVICE = StorageTables::Service.configure :backup, backup_config
+
+      include StorageTables::Service::SharedServiceTests
+      include ActiveJob::TestHelper
+
+      teardown do
+        FileUtils.rm_rf backup_config[:primary][:root]
+        FileUtils.rm_rf backup_config[:original][:root]
+      end
+
+      test "name" do
+        assert_equal :backup, @service.name
+      end
+
+      test "upload goes to primary service" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+
+        assert_changes -> { @service.primary.exist?(checksum) }, from: false, to: true do
+          @service.upload(checksum, StringIO.new(data))
+        end
+
+        assert_not @service.backup.exist?(checksum), "Backup should not have the file after upload"
+      end
+
+      test "download falls back to backup service when primary is missing" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+
+        # Upload only to backup
+        @service.backup.upload(checksum, StringIO.new(data))
+
+        # Should download from backup and trigger backfill
+        assert_equal data, @service.download(checksum)
+
+        # Verify backfill happened
+        assert @service.primary.exist?(checksum), "Primary should have the file after backfill"
+      end
+
+      test "exist? checks both primary and backup services" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+
+        assert_not @service.exist?(checksum), "File should not exist initially"
+
+        # Upload to primary only
+        @service.primary.upload(checksum, StringIO.new(data))
+
+        assert @service.exist?(checksum), "Should find file in primary"
+
+        # Remove from primary, upload to backup
+        @service.primary.delete(checksum)
+        @service.backup.upload(checksum, StringIO.new(data))
+
+        assert @service.exist?(checksum), "Should find file in backup"
+      end
+
+      test "backfill job is enqueued when downloading from backup" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+        @service.backup.upload(checksum, StringIO.new(data))
+
+        assert_enqueued_with(job: StorageTables::BackfillJob) do
+          @service.download(checksum)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a new `BackupService` for the `StorageTables` module, enabling fallback to a backup storage service when the primary service is missing a file. It also adds a background job for backfilling files from the backup to the primary service and includes comprehensive tests for the new functionality.

### New Backup Service Implementation:
* Added `BackupService` class in `lib/storage_tables/service/backup_service.rb`, which handles fallback to a backup service for missing files and includes methods for downloading, uploading, and backfilling files. It integrates with the primary and backup services and supports asynchronous backfilling via the `BackfillJob`.

### Background Job for Backfilling:
* Added `BackfillJob` in `app/jobs/storage_tables/backfill_job.rb` to perform asynchronous backfilling of files from the backup service to the primary service. It includes retry logic for integrity errors and discards jobs for file-not-found errors.

### Tests for Backup Service:
* Added `BackupServiceTest` in `test/service/backup_service_test.rb` to validate the functionality of the `BackupService`. Tests include scenarios for uploading, downloading with fallback, existence checks across services, and job enqueuing for backfilling.