### PR TITLE
feat: load storage configuration from environment-specific YAML files

### DIFF
--- a/lib/storage_tables/engine.rb
+++ b/lib/storage_tables/engine.rb
@@ -47,9 +47,8 @@ module StorageTables
 
         StorageTables::Blob.services = StorageTables::Service::Registry.new(configs)
 
-        if config_choice = Rails.configuration.storage_tables.service
-          StorageTables::Blob.service = StorageTables::Blob.services.fetch(config_choice)
-        end
+        config_choice = Rails.configuration.storage_tables.service
+        StorageTables::Blob.service = StorageTables::Blob.services.fetch(config_choice) if config_choice
       end
     end
 

--- a/lib/storage_tables/engine.rb
+++ b/lib/storage_tables/engine.rb
@@ -36,12 +36,20 @@ module StorageTables
 
     initializer "storage_tables.services" do
       ActiveSupport.on_load(:storage_tables_blob) do
-        # Use the application's configured Active Storage service.
-        configs = Rails.configuration.active_storage.service_configurations
+        configs = Rails.configuration.storage_tables.service_configurations ||=
+          begin
+            config_file = Rails.root.join("config/storage/#{Rails.env}.yml")
+            config_file = Rails.root.join("config/storage.yml") unless config_file.exist?
+            raise("Couldn't find Storage Tables configuration in #{config_file}") unless config_file.exist?
+
+            ActiveSupport::ConfigurationFile.parse(config_file)
+          end
+
         StorageTables::Blob.services = StorageTables::Service::Registry.new(configs)
 
-        config_choice = Rails.configuration.storage_tables.service
-        StorageTables::Blob.service = StorageTables::Blob.services.fetch(config_choice)
+        if config_choice = Rails.configuration.storage_tables.service
+          StorageTables::Blob.service = StorageTables::Blob.services.fetch(config_choice)
+        end
       end
     end
 

--- a/test/support/configuration_setup.rb
+++ b/test/support/configuration_setup.rb
@@ -17,8 +17,8 @@ end
 
 require "tmpdir"
 
-Rails.configuration.active_storage.service_configurations = SERVICE_CONFIGURATIONS.merge(
-  "local" => { "service" => "Disk", "root" => Dir.mktmpdir("active_storage_tests") }
+Rails.configuration.storage_tables.service_configurations = SERVICE_CONFIGURATIONS.merge(
+  "local" => { "service" => "Disk", "root" => Dir.mktmpdir("storage_tables_tests") }
 ).deep_stringify_keys
 
-Rails.configuration.active_storage.service = "local"
+Rails.configuration.storage_tables.service = "local"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,7 @@ Rails.configuration.storage_tables.service_configurations = SERVICE_CONFIGURATIO
 
 Rails.configuration.storage_tables.service = "local"
 
-module ActiveSupport 
+module ActiveSupport
   class TestCase
     self.file_fixture_path = File.expand_path("fixtures/files", __dir__)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,13 +22,13 @@ end
 
 require "tmpdir"
 
-Rails.configuration.active_storage.service_configurations = SERVICE_CONFIGURATIONS.merge(
+Rails.configuration.storage_tables.service_configurations = SERVICE_CONFIGURATIONS.merge(
   "local" => { "service" => "Disk", "root" => Dir.mktmpdir("storage_tables_tests") }
 ).deep_stringify_keys
 
-Rails.configuration.active_storage.service = "local"
+Rails.configuration.storage_tables.service = "local"
 
-module ActiveSupport
+module ActiveSupport 
   class TestCase
     self.file_fixture_path = File.expand_path("fixtures/files", __dir__)
 


### PR DESCRIPTION
This pull request refactors the configuration management for storage services in the `storage_tables` module, replacing references to `active_storage` with `storage_tables`. The changes ensure a more modular and independent configuration system for `storage_tables`.

### Refactoring configuration management:

* [`lib/storage_tables/engine.rb`](diffhunk://#diff-86f0a7c784873675299a26fe1b37305fb48829f84efe077ced4b6c6475ddba82L39-R51): Updated the initializer to load `storage_tables` service configurations from a dedicated YAML file (`config/storage/<environment>.yml` or `config/storage.yml` as a fallback). Added error handling for missing configuration files. Modified how the default service is fetched to handle cases where no service is explicitly configured.

* [`test/support/configuration_setup.rb`](diffhunk://#diff-a6365952e40bb6f539a1396da482e57fe0c5d42c803e22b88f225ceefbfb5d61L20-R24): Replaced `active_storage` configuration keys with `storage_tables` to align with the new module-specific configuration. Updated the temporary directory prefix for tests to `storage_tables_tests`.

* [`test/test_helper.rb`](diffhunk://#diff-ba37813ca277c227a74a372479b7b05b7f3ff085d890ab708f80d62573efdb7aL25-R29): Similar to `configuration_setup.rb`, updated `active_storage` references to `storage_tables` and adjusted the test setup to use the new configuration structure.