### PR TITLE
refactor: add mirror alias for backfill method in backup service

### DIFF
--- a/lib/storage_tables/service/backup_service.rb
+++ b/lib/storage_tables/service/backup_service.rb
@@ -12,8 +12,6 @@ module StorageTables
       delegate :delete, :url, :path_for, :upload, :url_for_direct_upload,
                :headers_for_direct_upload, :compose, to: :primary
 
-      alias mirror backfill
-
       def download(checksum, &)
         primary.download(checksum, &)
       rescue StorageTables::FileNotFoundError
@@ -76,6 +74,8 @@ module StorageTables
         @primary = primary
         @backup = backup
       end
+
+      alias mirror backfill
     end
   end
 end

--- a/lib/storage_tables/service/backup_service.rb
+++ b/lib/storage_tables/service/backup_service.rb
@@ -12,6 +12,8 @@ module StorageTables
       delegate :delete, :url, :path_for, :upload, :url_for_direct_upload,
                :headers_for_direct_upload, :compose, to: :primary
 
+      alias mirror backfill
+
       def download(checksum, &)
         primary.download(checksum, &)
       rescue StorageTables::FileNotFoundError

--- a/test/service/backup_service_test.rb
+++ b/test/service/backup_service_test.rb
@@ -95,6 +95,16 @@ module StorageTables
         assert @service.primary.exist?(checksum), "File should exist in primary after backfill"
       end
 
+      test "#mirror copies file from backup to primary" do
+        data = "Test data"
+        checksum = generate_checksum(data)
+        @service.backup.upload(checksum, StringIO.new(data))
+
+        @service.mirror(checksum)
+
+        assert @service.primary.exist?(checksum), "File should exist in primary after mirror"
+      end
+
       test "#exist? enqueues backfill job when file is only in backup" do
         data = "Test data"
         checksum = generate_checksum(data)


### PR DESCRIPTION
# Description
When switching from mirror service to backup service there could still be mirror jobs that needs to be run. This change allows mirror jobs to still perform and still copy a file from one place to the other.