### PR TITLE
feat: implement blob URL generation

### DIFF
--- a/app/models/storage_tables/blobs/servable.rb
+++ b/app/models/storage_tables/blobs/servable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module StorageTables
+  module Blobs
+    module Servable # :nodoc:
+      def content_type_for_serving
+        forcibly_serve_as_binary? ? StorageTables.binary_content_type : content_type
+      end
+
+      def forced_disposition_for_serving
+        return :attachment if forcibly_serve_as_binary? || !allowed_inline?
+
+        nil
+      end
+
+      private
+
+      def forcibly_serve_as_binary?
+        StorageTables.content_types_to_serve_as_binary.include?(content_type)
+      end
+
+      def allowed_inline?
+        StorageTables.content_types_allowed_inline.include?(content_type)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@
 Rails.application.routes.draw do
   scope StorageTables.routes_prefix do
     put "/disk/:encoded_token" => "storage_tables/disk#update", as: :update_storage_tables_disk_service
+    get "/disk/:encoded_token" => "storage_tables/disk#show", as: :show_storage_tables_disk_service
   end
 end

--- a/lib/storage_tables/service/disk_service.rb
+++ b/lib/storage_tables/service/disk_service.rb
@@ -102,6 +102,31 @@ module StorageTables
 
       private
 
+      def private_url(checksum, expires_in:, content_type:, disposition:, **)
+        generate_url(checksum, expires_in: expires_in, content_type: content_type,
+                               disposition: disposition)
+      end
+
+      def public_url(checksum, content_type: nil, disposition: :attachment, **)
+        generate_url(checksum, expires_in: nil, content_type: content_type,
+                               disposition: disposition)
+      end
+
+      def generate_url(checksum, expires_in:, content_type:, disposition:)
+        verified_key_with_expiration = StorageTables.verifier.generate(
+          {
+            checksum:,
+            disposition:,
+            content_type: content_type,
+            service_name: name
+          },
+          expires_in: expires_in,
+          purpose: :blob_url
+        )
+
+        url_helpers.show_storage_tables_disk_service_url(verified_key_with_expiration, **url_options)
+      end
+
       def folder_for(checksum)
         "#{checksum[0]}/#{checksum[1..2]}/#{checksum[3..4]}"
       end
@@ -127,6 +152,10 @@ module StorageTables
         end
 
         StorageTables::Current.url_options
+      end
+
+      def url_helpers
+        @url_helpers ||= Rails.application.routes.url_helpers
       end
 
       def stream(checksum)

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -126,6 +126,14 @@ module StorageTables
       assert_match(%r{/rails/storage_tables/disk/}, url)
     end
 
+    test "url" do
+      blob = create_blob
+
+      expected_url = "https://example.com/rails/storage_tables/disk/#{blob.checksum}"
+
+      assert_equal expected_url.first(46), blob.url.first(46)
+    end
+
     ## StorageTables::Blob.where_checksum
 
     test "where_checksum" do


### PR DESCRIPTION
This pull request enhances the `StorageTables` module by introducing functionality for generating URLs for blobs, improving URL handling for private and public files, and adding corresponding tests. It also updates the routing configuration to support these changes.

### Enhancements to Blob URL Handling:
* Added a new `Servable` module to `StorageTables::Blobs`, which provides methods for determining content type and disposition for serving files (`content_type_for_serving`, `forced_disposition_for_serving`) and includes logic for binary serving and inline allowance checks (`forcibly_serve_as_binary?`, `allowed_inline?`) (`[app/models/storage_tables/blobs/servable.rbR1-R27](diffhunk://#diff-a383c0974e046a40d73a43e1329994b29b865dd8250b629a71ef831e01fefc11R1-R27)`).
* Updated the `Blob` model to include the `Servable` module and added a `url` method for generating signed or public URLs for blobs, depending on their privacy settings (`[[1]](diffhunk://#diff-fe81ae21e2b8cd4244019e0afa6ecd003bbb3aa4bcceb19ec3845a1362ce2836R7)`, `[[2]](diffhunk://#diff-fe81ae21e2b8cd4244019e0afa6ecd003bbb3aa4bcceb19ec3845a1362ce2836R164-R172)`).

### URL Generation for Disk Service:
* Added methods in `DiskService` for generating private (`private_url`) and public (`public_url`) URLs, along with a helper method (`generate_url`) to centralize the URL creation logic. These methods leverage a signed key with expiration for private URLs and route helpers for constructing the URLs (`[[1]](diffhunk://#diff-b1f934cd1f34b1d94ecce8768c5b7b2323e69f33dce6f4c1ecea6cda1cb0ec34R105-R129)`, `[[2]](diffhunk://#diff-b1f934cd1f34b1d94ecce8768c5b7b2323e69f33dce6f4c1ecea6cda1cb0ec34R157-R160)`).

### Routing Updates:
* Added a new route to handle `GET` requests for showing disk service URLs (`config/routes.rb`) (`[config/routes.rbR6](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5R6)`).

### Testing:
* Added a test case in `BlobTest` to validate the correctness of the generated blob URLs (`[test/models/blob_test.rbR129-R136](diffhunk://#diff-09542e181ab32fe1872babc12d43499a02dd4b3c9387e9089f450d6fca4c077aR129-R136)`).