### PR TITLE
89 rename attachment methods to has one stored and has many stored

### DIFF
--- a/lib/storage_tables/attachable/model.rb
+++ b/lib/storage_tables/attachable/model.rb
@@ -7,7 +7,7 @@ module StorageTables
       extend ActiveSupport::Concern
 
       class_methods do # rubocop:disable Metrics/BlockLength
-        def has_one_stored(name, class_name:)
+        def has_one_stored(name, class_name:) # rubocop:disable Naming/PredicatePrefix
           define_method(name) do
             @storage_tables_attached ||= {}
             @storage_tables_attached[name.to_sym] ||= StorageTables::Attachable::One.new(name.to_s, self)
@@ -51,7 +51,7 @@ module StorageTables
           has_one_stored(**)
         end
 
-        def has_many_stored(name, class_name:)
+        def has_many_stored(name, class_name:) # rubocop:disable Naming/PredicatePrefix
           define_method(name) do
             @storage_tables_attached ||= {}
             @storage_tables_attached[name.to_sym] ||= StorageTables::Attachable::Many.new(name.to_s, self)

--- a/lib/storage_tables/reflection.rb
+++ b/lib/storage_tables/reflection.rb
@@ -5,17 +5,17 @@ module StorageTables
   module Reflection
     # Holds all the metadata about a has_one_attached attachment as it was
     # specified in the Active Record class.
-    class StoredOneAttachmentReflection < ActiveRecord::Reflection::MacroReflection # :nodoc:
+    class HasOneStoredAttachmentReflection < ActiveRecord::Reflection::MacroReflection # :nodoc:
       def macro
-        :stored_one_attachment
+        :has_one_stored
       end
     end
 
     # Holds all the metadata about a has_many_attached attachment as it was
     # specified in the Active Record class.
-    class StoredManyAttachmentsReflection < ActiveRecord::Reflection::MacroReflection # :nodoc:
+    class HasManyStoredAttachmentsReflection < ActiveRecord::Reflection::MacroReflection # :nodoc:
       def macro
-        :stored_many_attachments
+        :has_many_stored
       end
     end
 
@@ -28,10 +28,10 @@ module StorageTables
 
       def reflection_class_for(macro)
         case macro
-        when :stored_one_attachment
-          StoredOneAttachmentReflection
-        when :stored_many_attachments
-          StoredManyAttachmentsReflection
+        when :has_one_stored || :stored_one_attachment
+          HasOneStoredAttachmentReflection
+        when :has_many_stored || :stored_many_attachments
+          HasManyStoredAttachmentsReflection
         else
           super
         end

--- a/test/models/reflection_test.rb
+++ b/test/models/reflection_test.rb
@@ -33,7 +33,7 @@ module StorageTables
       assert_equal [User], reflections.collect(&:active_record).uniq
       assert_equal [:avatar, :highlights],
                    reflections.collect(&:name)
-      assert_equal [:stored_one_attachment, :stored_many_attachments],
+      assert_equal [:has_one_stored, :has_many_stored],
                    reflections.collect(&:macro)
     end
   end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  stored_one_attachment :avatar, class_name: "StorageTables::UserAvatarAttachment"
-  stored_many_attachments :highlights, class_name: "StorageTables::UserPhotoAttachment"
+  has_one_stored :avatar, class_name: "StorageTables::UserAvatarAttachment"
+  has_many_stored :highlights, class_name: "StorageTables::UserPhotoAttachment"
 
   validates :name, presence: true
 end
 
 class Group < ApplicationRecord
-  stored_one_attachment :image, class_name: "StorageTables::GroupAttachment"
+  has_one_stored :image, class_name: "StorageTables::GroupAttachment"
 end
 
 module StorageTables


### PR DESCRIPTION
This pull request refactors the attachment API in the `storage_tables` system to use new, more descriptive method names and reflection classes, while maintaining backward compatibility through deprecation warnings. The main goal is to replace the old `stored_one_attachment` and `stored_many_attachments` methods with `has_one_stored` and `has_many_stored`, respectively, and update the corresponding reflection logic and tests.

**API and Reflection Renaming:**

* The methods for declaring attachments on models have been renamed from `stored_one_attachment` and `stored_many_attachments` to `has_one_stored` and `has_many_stored`. Backward compatibility is maintained by keeping the old methods as wrappers that emit deprecation warnings. (`lib/storage_tables/attachable/model.rb`) [[1]](diffhunk://#diff-988caa5eea9186d8eaba4f7d5f1dfa44ae7778db86a00fdb576481f344c17c0dL10-R10) [[2]](diffhunk://#diff-988caa5eea9186d8eaba4f7d5f1dfa44ae7778db86a00fdb576481f344c17c0dL45-R54) [[3]](diffhunk://#diff-988caa5eea9186d8eaba4f7d5f1dfa44ae7778db86a00fdb576481f344c17c0dL72-R97)
* The reflection classes and macros have been renamed to match the new method names, and the reflection logic is updated to recognize both old and new macros for compatibility. (`lib/storage_tables/reflection.rb`) [[1]](diffhunk://#diff-938a0ec05a4aee20122194afd728283cbaf9916cdfea6c8e1fcef5b2951c8936L8-R18) [[2]](diffhunk://#diff-938a0ec05a4aee20122194afd728283cbaf9916cdfea6c8e1fcef5b2951c8936L31-R34)

**Test and Usage Updates:**

* All usages in test models and test cases have been updated to use the new API (`has_one_stored`, `has_many_stored`), and assertions in tests now expect the new macro names. (`test/support/models.rb`, `test/models/reflection_test.rb`) [[1]](diffhunk://#diff-4b6a90af0c0e6a7742a9b9f1d2b14fd9536293b05f90fc9fbd847ecb0d0fda82L4-R11) [[2]](diffhunk://#diff-800c90de71c96f3a991d3901e89c1ef4e9c358edf53b0327cdf214ec6a291a24L36-R36)