### PR TITLE
feat: handle race conditions on blob creation with retries

### DIFF
--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -35,14 +35,10 @@ module StorageTables
       raise StorageTables::ActiveRecordError, "Cannot delete blob attached to a record" if attachments_count.positive?
 
       delete_result = service.delete(checksum)
-
-      begin
-        super
-      rescue StandardError
-        service.restore(checksum, delete_result)
-
-        raise
-      end
+      super
+    rescue StandardError
+      service.restore(checksum, delete_result)
+      raise
     end
 
     # Check if file exists on disk
@@ -63,23 +59,21 @@ module StorageTables
       end
 
       def create_after_unfurling!(...)
-        attempts = 0
-        begin
-          blob = build_after_unfurling(...)
-          blob.save!
-          blob
-        rescue ActiveRecord::RecordNotUnique
-          # Race condition: another process saved the same checksum between our
-          # find_by_checksum check and save!. The blob already exists, so return
-          # it. If it was deleted in that narrow window, retry once; after that
-          # re-raise so the caller sees a real error.
-          existing = find_by_checksum(blob.checksum)
-          return existing if existing
+        blob = build_after_unfurling(...)
+        blob.save!
+        blob
+      rescue ActiveRecord::RecordNotUnique
+        # Race condition: another process saved the same checksum between our
+        # find_by_checksum check and save!. The blob already exists, so return
+        # it. If it was deleted in that narrow window, retry once; after that
+        # re-raise so the caller sees a real error.
+        existing = find_by_checksum(blob.checksum)
+        return existing if existing
 
-          attempts += 1
-          retry if attempts <= 1
-          raise
-        end
+        attempts ||= 0
+        attempts += 1
+        retry if attempts <= 1
+        raise
       end
 
       # Creates a new blob instance and then uploads the contents of
@@ -97,18 +91,16 @@ module StorageTables
       # Once the form using the direct upload is submitted, the blob can be associated with the right record using
       # the signed ID.
       def create_before_direct_upload!(byte_size:, checksum:, content_type:, metadata: nil)
-        attempts = 0
-        begin
-          create!(byte_size:, checksum:, content_type:, metadata:)
-        rescue ActiveRecord::RecordNotUnique
-          # Same race condition as create_after_unfurling! — see comment there.
-          existing = find_by_checksum(checksum)
-          return existing if existing
+        create!(byte_size:, checksum:, content_type:, metadata:)
+      rescue ActiveRecord::RecordNotUnique
+        # Same race condition as create_after_unfurling! — see comment there.
+        existing = find_by_checksum(checksum)
+        return existing if existing
 
-          attempts += 1
-          retry if attempts <= 1
-          raise
-        end
+        attempts ||= 0
+        attempts += 1
+        retry if attempts <= 1
+        raise
       end
 
       def existing_blob(checksum)

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -75,7 +75,7 @@ module StorageTables
           # re-raise so the caller sees a real error.
           existing = find_by_checksum(blob.checksum)
           return existing if existing
-          
+
           attempts += 1
           retry if attempts <= 1
           raise

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -75,6 +75,7 @@ module StorageTables
           # re-raise so the caller sees a real error.
           existing = find_by_checksum(blob.checksum)
           return existing if existing
+          
           attempts += 1
           retry if attempts <= 1
           raise
@@ -103,6 +104,7 @@ module StorageTables
           # Same race condition as create_after_unfurling! — see comment there.
           existing = find_by_checksum(checksum)
           return existing if existing
+
           attempts += 1
           retry if attempts <= 1
           raise

--- a/app/models/storage_tables/blob.rb
+++ b/app/models/storage_tables/blob.rb
@@ -63,7 +63,22 @@ module StorageTables
       end
 
       def create_after_unfurling!(...)
-        build_after_unfurling(...).tap(&:save!)
+        attempts = 0
+        begin
+          blob = build_after_unfurling(...)
+          blob.save!
+          blob
+        rescue ActiveRecord::RecordNotUnique
+          # Race condition: another process saved the same checksum between our
+          # find_by_checksum check and save!. The blob already exists, so return
+          # it. If it was deleted in that narrow window, retry once; after that
+          # re-raise so the caller sees a real error.
+          existing = find_by_checksum(blob.checksum)
+          return existing if existing
+          attempts += 1
+          retry if attempts <= 1
+          raise
+        end
       end
 
       # Creates a new blob instance and then uploads the contents of
@@ -81,7 +96,17 @@ module StorageTables
       # Once the form using the direct upload is submitted, the blob can be associated with the right record using
       # the signed ID.
       def create_before_direct_upload!(byte_size:, checksum:, content_type:, metadata: nil)
-        create!(byte_size:, checksum:, content_type:, metadata:)
+        attempts = 0
+        begin
+          create!(byte_size:, checksum:, content_type:, metadata:)
+        rescue ActiveRecord::RecordNotUnique
+          # Same race condition as create_after_unfurling! — see comment there.
+          existing = find_by_checksum(checksum)
+          return existing if existing
+          attempts += 1
+          retry if attempts <= 1
+          raise
+        end
       end
 
       def existing_blob(checksum)

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -89,6 +89,7 @@ module StorageTables
           end
         end
       end
+    end
 
     test "download yields chunks" do
       blob   = create_blob data: "a" * 5.0625.megabytes

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -85,7 +85,7 @@ module StorageTables
       unsaved_blob.stub(:save!, -> { raise ActiveRecord::RecordNotUnique }) do
         StorageTables::Blob.stub(:build_after_unfurling, ->(**) { unsaved_blob }) do
           result = StorageTables::Blob.create_after_unfurling!(io:)
-          
+
           assert_equal existing_blob, result
         end
       end

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -73,6 +73,23 @@ module StorageTables
       assert_equal blob, blob2
     end
 
+    test "create_after_unfurling! returns existing blob on concurrent insert race" do
+      # Pre-existing blob (simulates the winner of the race)
+      existing_blob = create_file_blob
+      io = file_fixture("racecar.jpg").open
+
+      # Simulate the loser: build_after_unfurling returns a new unsaved blob,
+      # save! raises RecordNotUnique (as if another process just inserted it),
+      # and the rescue lookup finds the blob that already exists in the DB.
+      unsaved_blob = StorageTables::Blob.new(checksum: existing_blob.checksum)
+      unsaved_blob.stub(:save!, -> { raise ActiveRecord::RecordNotUnique }) do
+        StorageTables::Blob.stub(:build_after_unfurling, ->(**) { unsaved_blob }) do
+          result = StorageTables::Blob.create_after_unfurling!(io:)
+          assert_equal existing_blob, result
+        end
+      end
+    end
+
     test "download yields chunks" do
       blob   = create_blob data: "a" * 5.0625.megabytes
       chunks = []

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -85,6 +85,7 @@ module StorageTables
       unsaved_blob.stub(:save!, -> { raise ActiveRecord::RecordNotUnique }) do
         StorageTables::Blob.stub(:build_after_unfurling, ->(**) { unsaved_blob }) do
           result = StorageTables::Blob.create_after_unfurling!(io:)
+          
           assert_equal existing_blob, result
         end
       end

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -91,6 +91,22 @@ module StorageTables
       end
     end
 
+    test "create_before_direct_upload! returns existing blob on concurrent insert race" do
+      # Pre-existing blob (simulates the winner of the race)
+      existing_blob = create_file_blob
+      # Simulate the loser: create! raises RecordNotUnique (as if another process just inserted it),
+      # and the rescue lookup finds the blob that already exists in the DB.
+      StorageTables::Blob.stub(:create!, ->(**) { raise ActiveRecord::RecordNotUnique }) do
+        result = StorageTables::Blob.create_before_direct_upload!(
+          byte_size: existing_blob.byte_size,
+          checksum: existing_blob.checksum,
+          content_type: existing_blob.content_type
+        )
+
+        assert_equal existing_blob, result
+      end
+    end
+
     test "download yields chunks" do
       blob   = create_blob data: "a" * 5.0625.megabytes
       chunks = []

--- a/test/models/blob_test.rb
+++ b/test/models/blob_test.rb
@@ -76,20 +76,19 @@ module StorageTables
     test "create_after_unfurling! returns existing blob on concurrent insert race" do
       # Pre-existing blob (simulates the winner of the race)
       existing_blob = create_file_blob
-      io = file_fixture("racecar.jpg").open
+      file_fixture("racecar.jpg").open do |io|
+        # Simulate the loser: build_after_unfurling returns a new unsaved blob,
+        # save! raises RecordNotUnique (as if another process just inserted it),
+        # and the rescue lookup finds the blob that already exists in the DB.
+        unsaved_blob = StorageTables::Blob.new(checksum: existing_blob.checksum)
+        unsaved_blob.stub(:save!, -> { raise ActiveRecord::RecordNotUnique }) do
+          StorageTables::Blob.stub(:build_after_unfurling, ->(**) { unsaved_blob }) do
+            result = StorageTables::Blob.create_after_unfurling!(io:)
 
-      # Simulate the loser: build_after_unfurling returns a new unsaved blob,
-      # save! raises RecordNotUnique (as if another process just inserted it),
-      # and the rescue lookup finds the blob that already exists in the DB.
-      unsaved_blob = StorageTables::Blob.new(checksum: existing_blob.checksum)
-      unsaved_blob.stub(:save!, -> { raise ActiveRecord::RecordNotUnique }) do
-        StorageTables::Blob.stub(:build_after_unfurling, ->(**) { unsaved_blob }) do
-          result = StorageTables::Blob.create_after_unfurling!(io:)
-
-          assert_equal existing_blob, result
+            assert_equal existing_blob, result
+          end
         end
       end
-    end
 
     test "download yields chunks" do
       blob   = create_blob data: "a" * 5.0625.megabytes


### PR DESCRIPTION
This pull request improves the robustness of blob creation methods in `StorageTables::Blob` by handling rare race conditions that can occur when multiple processes attempt to create a blob with the same checksum at the same time. The changes ensure that, in the event of a race, the existing blob is returned rather than raising an error. Additionally, new tests have been added to verify this behavior.

**Concurrency and race condition handling:**

* Updated `create_after_unfurling!` to rescue `ActiveRecord::RecordNotUnique` errors, check for an existing blob by checksum, and return it if found. Retries once if the blob was deleted in a narrow window, otherwise raises the error.
* Updated `create_before_direct_upload!` with similar logic to handle race conditions during direct upload blob creation, ensuring the existing blob is returned if it already exists.

**Testing:**

* Added a test to verify that `create_after_unfurling!` returns the existing blob in the case of a concurrent insert race, simulating the race condition scenario.